### PR TITLE
Non ML Baseline and Overall Analysis

### DIFF
--- a/model_analysis.py
+++ b/model_analysis.py
@@ -1,0 +1,175 @@
+import pickle
+import pandas as pd
+import os
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+import argparse
+import ast
+import numpy as np
+
+
+def convert_to_mean(value):
+    if isinstance(value, str):
+        value = value.replace('np.int64(', '').replace(')', '')
+        value = value.replace('np.float64(', '').replace(')', '')
+        return np.mean(ast.literal_eval(value))
+    return value
+
+
+def load_models(embedding_size_path):
+    with open(embedding_size_path, "rb") as f:
+        embeddings_sizes= pickle.load(f)
+    sizes = []
+    model_names = []
+    for k, v in embeddings_sizes.items():
+        normalized_k = k.replace("/","_").replace("-","_").replace(".","_")
+        model_names.append(normalized_k)
+        sizes.append(v)
+
+    model_size_dict = dict(zip(model_names, sizes))
+    return model_size_dict
+
+
+
+def load_results(label, eval_results_dir, metrics, model_size_dict):
+    #  List to store DataFrames
+    dataframes = []
+
+    # Iterate over files in the directory
+    for file in os.listdir(eval_results_dir):
+        if label == "llm":
+             if file.endswith(".csv") and 'detailed' and 'llm' in file:  # Check if the file is a CSV
+                file_path = os.path.join(eval_results_dir, file)
+                dataframes.append(pd.read_csv(file_path))
+        elif label == "normalized_eval":
+            if file.endswith(".csv") and 'detailed' in file and 'norm' in file and 'traditional' in file:  # Check if the file is a CSV
+                file_path = os.path.join(eval_results_dir, file)
+                dataframes.append(pd.read_csv(file_path,
+                converters = {
+                        'jaccard_indices': convert_to_mean,
+                        'overlap_coefficients': convert_to_mean,
+                    }))
+        else:
+             if file.endswith(".csv") and 'detailed' in file and 'traditional' in file and "norm" not in file:  # Check if the file is a CSV
+                file_path = os.path.join(eval_results_dir, file)
+                print(file_path)
+                dataframes.append(pd.read_csv(file_path,
+                converters = {
+                        'jaccard_indices': convert_to_mean,
+                        'overlap_coefficients': convert_to_mean,
+                    }))
+
+    # combined all dfs into one
+    all_data = pd.concat(dataframes, ignore_index=True)
+    print(all_data)
+
+    # Group by `model_name`
+    base_metrics = ['model_name']
+    base_metrics.extend(metrics)
+    grouped = all_data[base_metrics].groupby("model_name")
+
+    # Create the aggregation dictionary based on metric list entered
+    agg_dict = {f"{metric}": "mean" for metric in metrics}
+
+    # Aggregate Metrics
+    agg_metrics = grouped.agg(agg_dict).reset_index()
+
+    agg_metrics['model_name_normalized'] = agg_metrics['model_name'].replace("/","_").replace("-","_").replace(".","_")
+    agg_metrics['embedding_size'] = agg_metrics['model_name_normalized'].map(model_size_dict).fillna(0)
+    print(f"Result Type: {label}\n ------")
+    print(agg_metrics)
+
+    directories = [f"{eval_results_dir}/result_analysis",f"{eval_results_dir}/figs"]
+
+    for directory in directories:
+        if not os.path.exists(directory):
+                os.makedirs(directory)
+                print(f"Directory created: {directory}")
+
+    # save as csv
+
+
+    agg_metrics.to_csv(f'{eval_results_dir}/result_analysis/metric_results_{label}.csv')
+
+    return agg_metrics
+
+
+def plot_metrics(label, metric, agg_metrics, color_map, eval_results_dir):
+
+    # Sort the DataFrame by the metric in descending order
+    sorted_data = agg_metrics.sort_values(by=metric, ascending=True)
+
+    # Map colors to the sorted data
+    sorted_colors = sorted_data["embedding_size"].map(color_map)
+
+    # Bar plot
+    plt.figure(figsize=(8, 6))
+    plt.barh(sorted_data["model_name"], sorted_data[metric], color=sorted_colors)
+
+    # Create a custom legend
+    handles = [plt.Rectangle((0, 0), 1, 1, color=color_map[size]) for size in color_map]
+    labels = [f"{size}" for size in color_map]
+    plt.legend(handles, labels, title="Embedding Dim", loc="upper center", bbox_to_anchor=(0.5, -0.2))
+
+    # Customize plot
+    plt.title(f"{metric} by Model Name - {label}")
+    plt.xlabel(metric)
+    plt.ylabel("Model Name")
+    plt.tight_layout()
+    plt.savefig(f"{eval_results_dir}/figs/{label}_{metric}_by_model_name.png")
+
+
+
+def main(llm, k, embedding_sizes_path, eval_results_dir):
+    labels = ['traditional_eval','normalized_eval']
+    if llm:
+        labels.append('llm')
+    print(labels)
+
+    # may need to adjust if new embedding dims are added
+    color_map = {
+        384.: "blue",  # Color for embedding size 348
+        768.: "green",  # Color for embedding size 768
+        0.: "pink",
+    }
+    model_size_dict = load_models(embedding_sizes_path)
+
+    # metric sets
+    traditional_metrics = [f'precision@{k}', f'recall@{k}', f'ndcg@{k}', 'reciprocal_rank',
+               'average_precision','jaccard_indices','overlap_coefficients']
+    llm_metrics = [f'on_topic_number@{k}', f'on_topic_rate@{k}']
+
+
+    for label in labels:
+        if label == 'llm':
+             # llm judge metrics
+             agg_metrics = load_results(label,  eval_results_dir=eval_results_dir, metrics=llm_metrics, model_size_dict=model_size_dict)
+             for metric in llm_metrics:
+                plot_metrics(label, metric, agg_metrics, color_map, eval_results_dir)
+        else:
+             # traditional metrics
+             agg_metrics = load_results(label, eval_results_dir=eval_results_dir, metrics=traditional_metrics, model_size_dict=model_size_dict)
+             for metric in traditional_metrics:
+                plot_metrics(label, metric, agg_metrics, color_map, eval_results_dir)
+
+
+
+if __name__ == "__main__":
+     # Create the argument parser
+     parser = argparse.ArgumentParser(description="Compare model results")
+      # Add arguments
+     parser.add_argument("--eval_results_dir", default="evaluation_results/", type=str, help="Eval results directory")
+     parser.add_argument("--embedding_sizes_path", type=str, help="Path to embedding sizes dict.")
+     parser.add_argument("--k", type=int, default=2, help="Top-K results used in retrieval being evaluated.")
+     parser.add_argument("--llm", type=bool, default=False, help="whether LLM judge reuslts are included")
+
+     args = parser.parse_args()
+     # Call the main function with parsed arguments
+     main(
+         llm=args.llm,
+         k=args.k,
+         embedding_sizes_path=args.embedding_sizes_path,
+         eval_results_dir = args.eval_results_dir
+     )
+

--- a/non_ml_comparison.py
+++ b/non_ml_comparison.py
@@ -1,0 +1,266 @@
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+from rank_bm25 import BM25Okapi
+from nltk.tokenize import word_tokenize
+import pandas as pd
+import numpy as np
+from urllib.parse import urlparse, urlunparse
+import nltk
+from evaluation_pipeline.retrieval import process_history, convert_dict_to_df
+from rank_bm25 import BM25Okapi
+import argparse
+
+
+# Ensure NLTK tokenizer data is available
+nltk.download("punkt")
+
+def normalize_url(url):
+    parsed = urlparse(url)
+    # Remove fragments and queries, keep scheme + netloc + path
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, '', '', ''))
+
+
+
+def process_data(history_file_path, query_file_path):
+    # Define Corpus and Queries
+    history = process_history(row_limit=10001, history_file_path=history_file_path)
+    history['norm_url'] = history['url'].apply(normalize_url)
+    query_set = pd.read_csv(query_file_path)
+    query_set['norm_url'] = query_set['url'].apply(normalize_url)
+    history['index_col'] = history.index
+    query_list = query_set[['search_query','url','norm_url']]
+    relevant_docs = pd.merge(query_list, history, on='url', how='inner')
+    norm_relevant_docs = pd.merge(query_list, history, on='norm_url', how='inner')
+    relevant_docs = relevant_docs[['search_query','url','index_col','title','description','combined_text']]
+    unique_search_query_df = pd.DataFrame(relevant_docs.groupby('search_query').agg({
+        'url': list,   # Combine all URLs for the same query into a list
+        'index_col': list,  # Optionally include the index as a list
+        'title': list,
+        'description': list,
+        'combined_text': list,
+    }).reset_index())
+
+    norm_relevant_docs = norm_relevant_docs[['search_query','norm_url','index_col','title','description','combined_text']]
+
+    norm_unique_search_query_df = pd.DataFrame(norm_relevant_docs.groupby('search_query').agg({
+        'norm_url': list,
+        'index_col': list,  # Optionally include the index as a list
+        'title': list,
+        'description': list,
+        'combined_text': list,
+    }).reset_index())
+
+    return history, unique_search_query_df, query_list, query_set, norm_unique_search_query_df
+
+def create_ground_truth(query_list, unique_search_query_df, norm_unique_search_query_df, history, query_set):
+    query_ids = {query: str(hash(query)) for query in query_list['search_query'].unique()}
+    unique_search_query_df['query_id'] = unique_search_query_df['search_query'].map(query_ids)
+    norm_unique_search_query_df['query_id'] = norm_unique_search_query_df['search_query'].map(query_ids)
+    query_lookup = {}
+    for query in unique_search_query_df['search_query'].unique():
+        print(query)
+        query_id = query_ids[query]
+        query_lookup[query_id] = query
+    documents = history['combined_text'].to_list()
+    queries = query_set['search_query'].unique()
+
+    ground_truth = dict(zip(unique_search_query_df['query_id'], unique_search_query_df['index_col']))
+    ground_truth_urls = dict(zip(unique_search_query_df['query_id'], unique_search_query_df['url']))
+    norm_ground_truth = dict(zip(norm_unique_search_query_df['query_id'], norm_unique_search_query_df['index_col']))
+    norm_ground_truth_urls = dict(zip(norm_unique_search_query_df['query_id'], norm_unique_search_query_df['norm_url']))
+    return ground_truth, ground_truth_urls, unique_search_query_df, query_ids, documents, queries, query_lookup, norm_ground_truth, norm_ground_truth_urls
+
+
+
+# TF-IDF Retrieval
+def tfidf_retrieval(history, unique_search_query_df, top_k):
+    vectorizer = TfidfVectorizer()
+    tfidf_matrix = vectorizer.fit_transform(history["combined_text"])
+    results = {}
+
+    for i, row in unique_search_query_df.iterrows():
+        query_id = row['query_id']
+        query_matrix = vectorizer.transform([row['search_query']])
+        similarities = cosine_similarity(query_matrix, tfidf_matrix).flatten()
+        distances = 1 - similarities
+        ranked_indices = similarities.argsort()[::-1][:top_k]
+
+
+        retrievals = [
+            {
+                "id": history.iloc[idx]["index_col"],  # Use original index from `history`
+                "title": history.iloc[idx]["title"],
+                "url": history.iloc[idx]["url"],
+                "combined_text": history.iloc[idx]["combined_text"],
+                "distance": distances[idx]
+            }
+            for idx in ranked_indices
+        ]
+        results[query_id] = retrievals
+    return results
+
+# BM25 Retrieval
+def bm25_retrieval(history, unique_search_query_df, top_k):
+    tokenized_corpus = [word_tokenize(doc.lower()) for doc in history["combined_text"]]
+    bm25 = BM25Okapi(tokenized_corpus)
+    results = {}
+
+    for i, row in unique_search_query_df.iterrows():
+        query_id = row['query_id']
+        tokenized_query = word_tokenize(row['search_query'].lower())
+        scores = bm25.get_scores(tokenized_query)
+        ranked_indices = np.argsort(scores)[::-1][:top_k]
+
+        retrievals = [
+            {
+                "id": history.iloc[idx]["index_col"],  # Use original index from `history`
+                "title": history.iloc[idx]["title"],
+                "url": history.iloc[idx]["url"],
+                "combined_text": history.iloc[idx]["combined_text"],
+                "distance": scores[idx]
+            }
+            for idx in ranked_indices
+        ]
+        results[query_id] =  retrievals
+    return results
+
+
+def exact_match_retrieval(history, unique_search_query_df, top_k):
+    """
+    Exact Match Retrieval: Matches documents where the query terms exactly match the document terms.
+    
+    Args:
+        history (pd.DataFrame): DataFrame containing the documents with `combined_text` and metadata (e.g., title, URL, index_col).
+        unique_search_query_df (pd.DataFrame): DataFrame with search queries and associated metadata.
+        top_k (int): Number of top results to retrieve for each query.
+
+    Returns:
+        list[dict]: A list of dictionaries containing the retrieval results for each query.
+    """
+    results = {}
+
+    for i, row in unique_search_query_df.iterrows():
+        query_id = row['query_id']
+        query = row['search_query'].lower()
+       # query_terms = query.split()  # Split query into words
+        #pattern = r"\b(" + "|".join(query_terms) + r")\b"
+        #matches = history[history['combined_text'].str.contains(pattern, case=False, na=False, regex=True)]
+
+        # Filter documents in the history DataFrame where `combined_text` contains the exact query terms
+        matches = history[history['combined_text'].str.contains(rf'\b{query}\b', case=False, na=False)]
+
+        # Limit to top_k results
+        matches = matches.head(top_k)
+        # Format the retrieval results
+        retrievals = [
+            {
+                "id": doc["index_col"],
+                "title": doc["title"],
+                "url": doc["url"],
+                "combined_text": doc["combined_text"],
+                "distance": 0  # Exact match has no distance concept, so we use 0 as a placeholder
+            }
+            for _, doc in matches.iterrows()
+        ]
+
+        results[query_id] =  retrievals
+
+    return results
+
+
+
+def exact_match_terms_retrieval_frecency(history, unique_search_query_df, top_k):
+    """
+    Exact Match Retrieval: Matches documents where the query terms exactly match the document terms.
+    
+    Args:
+        history (pd.DataFrame): DataFrame containing the documents with `combined_text` and metadata (e.g., title, URL, index_col).
+        unique_search_query_df (pd.DataFrame): DataFrame with search queries and associated metadata.
+        top_k (int): Number of top results to retrieve for each query.
+
+    Returns:
+        list[dict]: A list of dictionaries containing the retrieval results for each query.
+    """
+    results = {}
+
+    for i, row in unique_search_query_df.iterrows():
+        query_id = row['query_id']
+        query = row['search_query'].lower()
+        query_terms = query.split()  # Split query into words
+        pattern = r"\b(" + "|".join(query_terms) + r")\b"
+        matches = history[history['combined_text'].str.contains(pattern, case=False, na=False,regex=True)].sort_values(by='frecency', ascending=False)
+
+        # Filter documents in the history DataFrame where `combined_text` contains the exact query terms
+#        matches = history[history['combined_text'].str.contains(rf'\b{query}\b', case=False, na=False)]
+
+        # Limit to top_k results
+        matches = matches.head(top_k)
+        # Format the retrieval results
+        retrievals = [
+            {
+                "id": doc["index_col"],
+                "title": doc["title"],
+                "url": doc["url"],
+                "combined_text": doc["combined_text"],
+                "distance": 0  # Exact match has no distance concept, so we use 0 as a placeholder
+            }
+            for _, doc in matches.iterrows()
+        ]
+
+        results[query_id] =  retrievals
+
+    return results
+
+
+# Run and Combine TF-IDF and BM25 Results
+def main(k, history_file_path, query_file_path):
+    history, unique_search_query_df, query_list, query_set,  norm_unique_search_query_df = process_data(history_file_path, query_file_path)
+    ground_truth, ground_truth_urls, unique_search_query_df, query_ids, documents, queries, query_lookup, norm_ground_truth, norm_ground_truth_urls = create_ground_truth(query_list, unique_search_query_df,  norm_unique_search_query_df, history, query_set)
+
+    
+    # retrieval
+    tfidf_results = tfidf_retrieval(history, unique_search_query_df, top_k=k)
+    bm25_results = bm25_retrieval(history, unique_search_query_df, top_k=k)
+    # Perform Exact Match Retrieval
+    exact_match_results = exact_match_retrieval(history, unique_search_query_df, top_k=k)
+    # exact match sort by freceny desc
+    exact_match_results_frecency = exact_match_terms_retrieval_frecency(history, unique_search_query_df, top_k=k)
+    
+    # Create Output DataFrames
+    # tfidf
+    tfidf_df = convert_dict_to_df(tfidf_results, query_lookup, ground_truth=ground_truth, ground_truth_urls=ground_truth_urls,  norm_ground_truth=norm_ground_truth, norm_ground_truth_urls=norm_ground_truth_urls, model_name="TF-IDF", k=k)
+
+    # bm25
+    bm25_df = convert_dict_to_df(bm25_results,query_lookup, ground_truth=ground_truth, ground_truth_urls=ground_truth_urls, norm_ground_truth=norm_ground_truth, norm_ground_truth_urls=norm_ground_truth_urls, model_name="BM25", k=k)
+
+    # exact match
+    exact_match_df = convert_dict_to_df(exact_match_results,query_lookup, ground_truth=ground_truth, ground_truth_urls=ground_truth_urls, norm_ground_truth=norm_ground_truth, norm_ground_truth_urls=norm_ground_truth_urls,model_name="exact_match", k=k)
+
+    # exact match (sort by frecency desc)
+    exact_match_results_frecency_df = convert_dict_to_df(exact_match_results_frecency,query_lookup, ground_truth=ground_truth, ground_truth_urls=ground_truth_urls, norm_ground_truth=norm_ground_truth, norm_ground_truth_urls=norm_ground_truth_urls,model_name="exact_match_terms_freceny", k=k)
+
+    
+    # Save Results to CSV
+    tfidf_df.to_csv("results/tfidf_retrieval_results.csv", index=False)
+    bm25_df.to_csv("results/bm25_retrieval_results.csv", index=False)
+    exact_match_df.to_csv("results/exact_match_retrieval_results.csv", index=False)
+    exact_match_results_frecency_df.to_csv("results/exact_match_frecency_retrieval_results.csv", index=False)
+
+
+if __name__ == "__main__":
+     # Create the argument parser
+     parser = argparse.ArgumentParser(description="Compare model results")
+      # Add arguments
+     parser.add_argument("--history_file_path", default="output.csv", type=str, help="File path for browsing history csv")
+     parser.add_argument("--golden_path", default="golden_query_set.csv",type=str, help="Path for golden query set")
+     parser.add_argument("--k", type=int, default=2, help="Top-K results used in retrieval being evaluated.")
+
+     args = parser.parse_args()
+     # Call the main function with parsed arguments
+     main(
+         k=args.k,
+         history_file_path= args.history_file_path,
+         query_file_path=args.golden_path
+     )
+
+

--- a/non_ml_comparison.py
+++ b/non_ml_comparison.py
@@ -249,7 +249,7 @@ def main(k, history_file_path, query_file_path):
 
 if __name__ == "__main__":
      # Create the argument parser
-     parser = argparse.ArgumentParser(description="Compare model results")
+     parser = argparse.ArgumentParser(description="Non ML retrieval")
       # Add arguments
      parser.add_argument("--history_file_path", default="output.csv", type=str, help="File path for browsing history csv")
      parser.add_argument("--golden_path", default="golden_query_set.csv",type=str, help="Path for golden query set")


### PR DESCRIPTION
# Overview 
This merge request contains the following changes: 
 
## Add comparison with "normalized" url 
- Based on initial review of retrieval, there are similar URLs (e.g. google mail variants, different 'edit' states of the same google doc) that were negatively counting toward the retrieval. Now, we have the ability to "normalize" the URL to allow comparison to the more root forms, while still ensuring they represent distinct pages.  
- The retrieval itself is the same, but in the construction of the ground truth, we add the normalized URL 
- For evaluation, we add another set of the same evaluation metrics, this time comparing against `norm_relevant_docs` (the expanded list) 
- Because we are only doing k=2, this will make recall look worse (because there are many variants of the 'same URL' not retrieved. It is expected to improve precision @ 2 and mean average precision 

## Understand lexical overlap of search query + retrieved 
Similar to the idea of exact match, added some metrics to help us understand the overlap of the search query with the 'combined_text'. Part of the goal with semantic search is to augment search when there is no/minimal keyword overlap (strategy, approach) <-- low lexical overlap, similar meaning, or when additional words change the meaning or context (e.g. work from home, not working from home) <-- high lexical overlap, opposite semantic meaning 

## Add comparison to non ML baseline 
- To contextualize performance of embedding models, added a script that does tf-idf, BM25, and exact match retrieval 
- Exact match was a bit tricky (is it exact match at the entire query? sub terms of query?). To keep it simple, I added both versions, the latter of which I also sort by frecency descending (the goal is to approximate current suggest functionality) 

## Add Overall Model Comparison 
- Add a script that takes all the evaluation results and creates plots of them for each metric, to make analysis easier 
