### PR TITLE
Refactor Evaluation Pipeline

### DIFF
--- a/evaluation_pipeline/pipeline_utils/evaluation.py
+++ b/evaluation_pipeline/pipeline_utils/evaluation.py
@@ -1,0 +1,290 @@
+import pandas as pd
+import numpy as np
+import os
+from typing import List
+import ast
+import argparse
+from sklearn.manifold import TSNE
+import matplotlib.pyplot as plt
+from textwrap import wrap
+import wandb
+from dotenv import load_dotenv
+from pipeline_utils.feature_extractor_optimized import FeatureExtractor
+from pipeline_utils.llm_judge import llm_as_judge
+from pipeline_utils.metrics import format_judge_response, run_traditional_eval
+from pipeline_utils.utils import convert_to_list, get_combined_texts_uniform_k
+
+
+def run_llm_judge(judge, query, retrieved_texts, k):
+    row = {'query': query}
+
+    # call llm
+    decisions = []
+    for retrieved_text in retrieved_texts:
+        try:
+            llm_judge_response = judge.evaluation_prompt(
+                query,
+                retrieved_text
+            )
+
+            response = format_judge_response(
+                llm_judge_response
+            )
+
+            decisions.append(
+                response['binary_decision']
+            )
+        except:
+            decisions.append(0)
+    # store results
+    row['decisions'] = decisions
+    row[f'on_topic_number@{k}'] = sum(decisions)
+    row[f'on_topic_rate@{k}'] = sum(decisions) / float(k)
+    return row
+
+
+def load_retrieved(file_path):
+
+    df = pd.read_csv(file_path,
+            converters={
+                'relevant_docs': convert_to_list,
+                'retrieved_ids': convert_to_list,
+                'combined_text': convert_to_list,
+                'retrieved_distances': convert_to_list,
+                'norm_relevant_docs': convert_to_list,
+                }
+    )
+
+    model_run_details = ast.literal_eval(
+        df['model_run_details'].iloc[0]
+    )
+
+    k = model_run_details['k']
+
+    df['combined_text'] = get_combined_texts_uniform_k(
+        df,
+        model_run_details['k']
+    )
+    return df, k, model_run_details
+
+def vectorized_evaluation(row, k, url_type):
+    if url_type == "norm":
+        relevant_prefix = "norm_"
+    elif url_type == "traditional":
+        relevant_prefix = ""
+    else:
+        ValueError("Only running for norm or traditional")
+
+    evaluated_query = run_traditional_eval(
+        query_id = row['query'],
+        query = row['query'],
+        relevant_docs=row[f'{relevant_prefix}relevant_docs'],
+        retrieved_docs=row['retrieved_ids'],
+        retrieved_distances = row['retrieved_distances'],
+        retrieved_texts = row['combined_text'],
+        relevant_texts =  row[f'{relevant_prefix}relevant_combined_text'],
+        k=k
+    )
+    return evaluated_query
+
+
+def vectorized_llm_evaluation(row, k, judge):
+    return run_llm_judge(
+        judge=judge,
+        query = row['query'],
+        retrieved_texts=row['combined_text'],
+        k=k
+    )
+
+def run_vectorized_traditional_eval(df, k):
+
+    df['evaluation'] = df.apply(
+        lambda row: vectorized_evaluation(
+            row,
+            k,
+            url_type='traditional'
+            ),
+        axis=1
+        )
+
+    df['norm_evaluation'] = df.apply(
+        lambda row: vectorized_evaluation(
+            row,
+            k,
+            url_type='norm'
+            ),
+        axis=1
+    )
+
+    evaluation_df = pd.DataFrame(
+        df['evaluation'].tolist()
+    )
+
+    norm_evaluation_df = pd.DataFrame(
+        df['norm_evaluation'].tolist()
+    )
+
+    return evaluation_df, norm_evaluation_df
+
+
+def run_vectorized_llm_eval(df, k, judge):
+
+    df['llm_evaluation'] = df.apply(
+        lambda row: vectorized_llm_evaluation(
+            row,
+            k,
+            judge)
+            ,
+        axis=1
+    )
+
+    llm_evaluation_df = pd.DataFrame(
+        df['llm_evaluation'].tolist()
+    )
+    return llm_evaluation_df
+
+
+def wandb_logging(df, k, model_run_details):
+    load_dotenv()
+    api_key = os.getenv("WANDB_API_KEY")
+    project = os.getenv("WANDB_PROJECT")
+    entity = os.getenv("WANDB_ENTITY")
+    wandb.login(key=api_key)  # Automatically uses the API key
+    wandb.init(
+    # set the wandb project where this run will be logged
+    project=project,
+    run_name=f"{model_run_details['model_name']}_{model_run_details['distance']}_{model_run_details['suffix']}_top{k}",
+
+    # track hyperparameters and run metadata
+    config={"model_name": model_run_details['model_name'],
+            "k": k,
+            "distance": model_run_details['distance'],
+            "quanitzed": model_run_details['quantized']
+    }
+)
+
+
+
+def evaluation_pipeline(run_llm_judge: bool, file_path, log_to_wandb, save_eval_dir, result_dir, specific_k=None):
+    print(f"Evaluating {file_path}")
+
+    retrieval_df, k, model_run_details = load_retrieved(file_path=file_path)
+
+    # give option to override k
+    if specific_k is None:
+        pass
+    else:
+        k = specific_k
+
+    if log_to_wandb:
+        wandb_logging(retrieval_df, k)
+
+    # run eval
+    results_df, norm_results_df = run_vectorized_traditional_eval(
+        retrieval_df,
+        k
+    )
+
+    # store results
+    dfs_to_return = []
+    df_labels = []
+
+    # original urls
+    dfs_to_return.append(results_df)
+    df_labels.append("traditional_eval")
+
+    #normalized urls
+    dfs_to_return.append(norm_results_df)
+    df_labels.append("norm_traditional_eval")
+
+    if run_llm_judge:
+        judge = llm_as_judge()
+        llm_results_df = run_vectorized_llm_eval(retrieval_df, k, judge)
+        dfs_to_return.append(llm_results_df)
+        df_labels.append("llm_eval")
+
+    for df, label in zip(dfs_to_return, df_labels):
+        df['model_name'] = model_run_details['model_name']
+        df['embedding_dim'] = model_run_details['embedding_dim']
+        df['model_run_details'] =  [model_run_details] * len(df)
+
+        summary_df = df.describe().reset_index()
+        summary_df = summary_df.loc[:, summary_df.columns != 'query_id'] if 'query_id' in summary_df.columns else summary_df
+        summary_table = wandb.Table(dataframe=summary_df)
+        averages = summary_df[summary_df['index'] == 'mean']
+
+        # Ensure the directory exits
+        save_eval_results_dir = result_dir.replace('results/',save_eval_dir)
+        if not os.path.exists(save_eval_results_dir):
+            os.makedirs(save_eval_results_dir)
+            print(f"Directory created: {save_eval_results_dir}")
+
+        if log_to_wandb:
+            wandb.log({label: summary_table})
+            wandb.log({"Averages": averages})
+            wandb.finish()
+        # write files
+        write_file_path = file_path.replace('_results.csv','').replace('.csv','').replace('non_ml_results/','').replace('results/',save_eval_dir)
+
+        summary_df.to_csv(f"{write_file_path}_{label}_aggregate_metrics.csv")
+        df.to_csv(f"{write_file_path}_{label}_detailed_metrics.csv")
+        
+    return write_file_path
+
+
+def visualize_embeddings(model_run_details, queries, file_name):
+    model_name = model_run_details['model_name']
+    quantized_model = model_run_details['quantized']
+    fe = FeatureExtractor(model_name=model_name, quantized=quantized_model)
+    embeddings = []
+    for query in queries:
+        query_embeddings = fe.get_embeddings([query])[0]
+        embeddings.append(query_embeddings)
+
+    tsne = TSNE(n_components=2, random_state=42, perplexity = 25)
+    reduced_embeddings = tsne.fit_transform(np.array(embeddings))
+
+    # Wrap text to a maximum width
+    wrapped_labels = [ "\n".join(wrap(label, width=25)) for label in queries ]  # 15 characters per line
+
+    # Plot with wrapped labels
+    fig, ax = plt.subplots(figsize=(10, 7))
+
+    plt.scatter([x[0] for x in reduced_embeddings], [x[1] for x in reduced_embeddings], c='orange', alpha=0.6)
+
+    for i, txt in enumerate(wrapped_labels):
+        ax.annotate(txt, (reduced_embeddings[i, 0], reduced_embeddings[i, 1]),fontsize=7,)
+
+    ax.set_xlabel('Dimension 1')
+    ax.set_ylabel('Dimension 2')
+    ax.set_title(f't-SNE Visualization of Embeddings for {model_name}')
+    try: 
+        wandb.log({"chart": wandb.Image(fig)})
+    except:
+        pass 
+    plt.savefig(f'figs/t_sne_embeddings_{file_name}.png', format='png', dpi=300, bbox_inches='tight')
+    plt.close()
+
+
+
+def main(use_llm_judge, file_path, log_to_wandb, save_eval_dir):
+    evaluation_pipeline(run_llm_judge = use_llm_judge, file_path=file_path, log_to_wandb=log_to_wandb, save_eval_dir=save_eval_dir)
+
+
+if __name__ == "__main__":
+      # Create the argument parser
+      parser = argparse.ArgumentParser(description="Run the evaluation pipeline with specified parameters.")
+
+      parser.add_argument("-f", type=str, help="Path to the file to be processed")
+      parser.add_argument("-log_to_wandb", type=str, default=False, help="Whether to log to Weights & Biases")
+
+      parser.add_argument("-llm",type=lambda x: str(x).lower() in ['true', '1', 'yes'],default=False,help="Whether or noto use LLM judge (default: False")
+
+      parser.add_argument("--save_eval_dir", type=str, default="evaluation_results/",help="directory to save eval results")
+
+      # Parse the command-line arguments
+      args = parser.parse_args()
+      main(use_llm_judge=args.llm, file_path=args.f, log_to_wandb=args.log_to_wandb, save_eval_dir=args.save_eval_dir)
+
+
+

--- a/evaluation_pipeline/pipeline_utils/feature_extractor_optimized.py
+++ b/evaluation_pipeline/pipeline_utils/feature_extractor_optimized.py
@@ -1,0 +1,65 @@
+import onnxruntime as ort
+import numpy as np
+from transformers import AutoTokenizer
+from optimum.onnxruntime import ORTModelForFeatureExtraction
+import pandas as pd
+import onnxruntime as ort
+import numpy as np
+from transformers import AutoTokenizer, pipeline
+from optimum.onnxruntime import ORTModelForFeatureExtraction
+
+class FeatureExtractor:
+    def __init__(self, model_name="Xenova/all-MiniLM-L6-v2", quantized=True, pooling='mean'):
+        print(f"Selected model is {model_name}")
+        # Load the ONNX model
+        # Initialize tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.quantized = quantized
+        self.pooling = pooling
+        if quantized:
+            file_name_suffix = "_quantized.onnx"
+        else:
+            file_name_suffix = ".onnx"
+        self.model = ORTModelForFeatureExtraction.from_pretrained(model_name, subfolder = "onnx", file_name=f"model{file_name_suffix}", trust_remote_code=True)
+        print(self.model.model_save_dir)
+        self.onnx_extractor = pipeline("feature-extraction",
+                                        model=self.model,
+                                        tokenizer=self.tokenizer,
+                                        truncation=True,
+                                        max_length=100)
+
+
+    def extract_features(self, text: str):
+        attention_mask = self.tokenizer(text)['attention_mask']
+        embeddings = self.onnx_extractor(text)
+        embeddings = np.squeeze(np.array(embeddings), axis=0)
+        return embeddings, attention_mask
+
+    def mean_pooling(self, embeddings, attention_mask):
+        expanded_attention_mask = np.expand_dims(attention_mask, axis=-1)
+        masked_embeddings = embeddings * expanded_attention_mask
+        # mean pooled masked
+        sum_embeddings = np.sum(masked_embeddings, axis=0)
+        sum_mask = np.sum(expanded_attention_mask, axis=0)
+        sum_mask = np.maximum(sum_mask, 1e-9)
+        mean_pooled = sum_embeddings / sum_mask
+        return mean_pooled
+
+    def cls_pooling(self, embeddings):
+        return embeddings[0]
+    
+    def get_embedding(self, text):
+        embeddings, attention_mask = self.extract_features(text)
+
+        # pooling
+        if self.pooling == 'mean':
+            pooled_embedding = self.mean_pooling(embeddings=embeddings,attention_mask=attention_mask)
+        elif self.pooling == 'cls':
+            pooled_embedding = self.cls_pooling(embeddings=embeddings)
+
+         # Normalize the returned data using L2 norm
+        norms = np.linalg.norm(pooled_embedding, axis=0)
+        normalized_data = pooled_embedding / np.clip(norms, a_min=1e-10, a_max=None)  # Prevent division by zero
+
+        return normalized_data
+

--- a/evaluation_pipeline/pipeline_utils/features.py
+++ b/evaluation_pipeline/pipeline_utils/features.py
@@ -1,0 +1,182 @@
+import pickle
+import pandas as pd
+import numpy as np
+import gc
+import yaml
+import sys
+import os
+from pipeline_utils.utils import clean_text, serialize_f32, normalize_url, log_performance, preprocess_url
+from pipeline_utils.feature_extractor_optimized import FeatureExtractor
+import time
+from pathlib import Path
+
+
+with open("evaluation_pipeline/model_config.yml", "r") as f:
+    config = yaml.safe_load(f)
+
+
+@log_performance
+def process_history(row_limit, preprocess,  history_file_path, features):
+    browsing_history = pd.read_csv(history_file_path).head(row_limit)
+
+    browsing_history['norm_url'] = browsing_history['url'].apply(normalize_url)
+
+    browsing_history["combined_text"] = browsing_history.apply(
+        lambda row: create_embedding_string(
+            row,
+            features,
+            preprocess=preprocess),
+        axis=1)
+
+    feature_string = '_'.join(features)
+
+    processed_history_file_path = f"../data/history_{preprocess*'preprocess_'}{row_limit}_{feature_string}.csv"
+
+    browsing_history.to_csv(processed_history_file_path)
+
+    print(f"Browsing history is {len(browsing_history)}")
+
+    return browsing_history, processed_history_file_path
+
+def create_embedding_string(row, features, preprocess):
+    """
+    Builds a combined embedding string from a set of features in a row.
+
+    - If preprocess=True, special logic is applied for 'title', 'description', and 'url':
+        - 'title' and 'description' are passed through clean_text().
+        - 'url' is passed through preprocess_url() and appended as `source: domain`.
+    - If preprocess=False, the raw feature values are simply converted to strings and joined.
+    - Any other feature is just included as is (converted to string).
+    
+    Parameters
+    ----------
+    row : pd.Series or dict-like
+        A single row of the dataframe.
+    features : list of str
+        Column names to include in the combined string.
+    preprocess : bool, optional
+        Whether to clean text fields and preprocess URL. Defaults to False.
+
+    Returns
+    -------
+    str
+        A single string combining all requested features.
+    """
+    processed_parts = []
+
+    for col in features:
+        value = row[col] if col in row else ""
+
+        if pd.isna(value):
+            value = ""
+
+        if preprocess:
+            # Special handling for url
+            if col == "url":
+                domain = preprocess_url(value)  # e.g. "example.com"
+                processed_parts.append({domain})
+            else:
+                processed_parts.append(clean_text(value))
+        else:
+            processed_parts.append(str(value))
+
+    # Join the parts with " "
+    return " ".join(processed_parts)
+
+
+def generate_embeddings(fe, texts):
+    """
+    Generates embeddings in a memory-efficient way using a generator.
+
+    Args:
+        fe: FeatureExtractor instance
+        texts (list or str): List of text strings or a single string.
+
+    Yields:
+        np.ndarray: Embedding for each text.
+    """
+    for text in texts:
+        embedding = fe.get_embedding(text)  # Get embedding for a single text
+        yield embedding  # Yield instead of storing everything in memory
+
+@log_performance
+def create_embeddings(fe,  history, model_run_details):
+    texts = history['combined_text'].values.tolist()
+
+    models_parameters = config["models"][model_run_details['model_name']]
+    print(f"Using prefix: {models_parameters['prefix_document']}")
+
+    texts_to_embed = [models_parameters['prefix_document'] + text for text in texts]
+
+    embeddings = list(generate_embeddings(fe, texts_to_embed))
+
+
+    # Save only the essential information
+    embeddings_dict = {model_run_details['model_name'] : embeddings}
+
+    embeddings_path = f"../data/embeddings_dict_{model_run_details['embedding_file_name']}.pkl"
+
+    with open(embeddings_path, "wb") as f:
+        pickle.dump(
+            embeddings_dict,
+            f
+        )
+    print(f"Embeddings written to {embeddings_path}")
+
+    return embeddings_path
+
+
+
+def feature_pipeline(history_file_path, model_run_details, embeddings_exist):
+    print(f" {'Using existing embeddings' if embeddings_exist else 'generating embeddings'}")
+
+    directory = Path("../data")
+    directory.mkdir(parents=True, exist_ok=True)  # Create if not exists
+
+    history, history_path = process_history(
+        model_run_details['row_limit'],
+        model_run_details['preprocess'],
+        history_file_path,
+        model_run_details['features']
+    )
+
+
+
+
+    if embeddings_exist:
+        print(f"Going to use pre-generated embeddings from {model_run_details['embedding_file_name']}")
+        embeddings_path = f"../data/embeddings_dict_{model_run_details['embedding_file_name']}.pkl"
+
+    else:
+        embedding_start = time.time()
+
+        fe = FeatureExtractor(
+            model_run_details['model_name'],
+            model_run_details['quantized'],
+            model_run_details['pooling'],
+        )
+
+        embeddings_path = create_embeddings(
+            fe,
+            history,
+            model_run_details
+        )
+        embedding_end = time.time()
+        print(f"Embeddings to {embedding_end - embedding_start} to generate")
+        print(f"Embeddings written to: {embeddings_path}")
+    
+        del fe
+        gc.collect()
+
+    return embeddings_path, history_path
+
+
+
+
+def main(history_file_path, model_run_details):
+    feature_pipeline(history_file_path, model_run_details)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/evaluation_pipeline/pipeline_utils/llm_judge.py
+++ b/evaluation_pipeline/pipeline_utils/llm_judge.py
@@ -1,0 +1,75 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+import torch
+
+
+
+class llm_as_judge:
+    def __init__(self):
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if self.device == "cuda":
+            self.model =  AutoModelForCausalLM.from_pretrained(
+            "microsoft/Phi-3-mini-4k-instruct",
+            device_map="auto",
+            torch_dtype="auto",
+            trust_remote_code=True,
+            )
+        else:
+            self.model =  AutoModelForCausalLM.from_pretrained(
+            "microsoft/Phi-3-mini-4k-instruct",
+            device_map="auto",
+            torch_dtype="auto",
+            trust_remote_code=True,
+            )
+
+
+        self.tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3-mini-4k-instruct")
+     
+
+    def evaluation_prompt(self, query, results, custom_prompt=None):
+        tokenizer = self.tokenizer
+        model = self.model
+        prompt = f'''Given the retrieval results URL metadata below, is the website primarily about query or strongly relevant to the query?
+
+        # Search Query: {query} 
+        
+        # Retrieved result: {results}
+        
+        # Evaluation 
+        Based on your reasoning, determine a relevance score between 0 and 1 (where 0 is not relevant, and 1 is highly relevant). Then, based on this score, assign a binary rating of 0 = not relevant or 1 = relevant. 
+
+        # Output format as a Dictionary
+         search_query: <search query>,
+         retrieved_result: <retrieved result>,
+         relevance_score: <score>,
+         binary_decison: 0 or 1,
+         Decision_Reason: <reason for decision>
+         
+         '''
+        if custom_prompt: 
+            print("Using custom prompt") 
+        else: 
+            pass
+   
+        messages = [
+            {"role": "system", "content": "You a judge who determines whether a returned web page is relevant to a user search query. The system cannot answer questions directly, only return relevant web pages."},
+            {"role": "user", "content": prompt},
+        ]
+
+        pipe = pipeline(
+            "text-generation",
+            model=model,
+            tokenizer=tokenizer,
+        )
+
+        generation_args = {
+            "max_new_tokens": 600,
+            "return_full_text": False,
+            "temperature": 0.0,
+            "do_sample": False,
+        }
+
+        output = pipe(messages, **generation_args)
+        print(output[0]['generated_text'])
+        return output
+
+

--- a/evaluation_pipeline/pipeline_utils/metrics.py
+++ b/evaluation_pipeline/pipeline_utils/metrics.py
@@ -1,0 +1,165 @@
+
+import numpy as np
+import json
+import re
+from sklearn.metrics import ndcg_score
+
+
+def calc_precision_at_k(relevant_docs, retrieved_docs, k):
+    """
+    Compute Precision@K.
+    Parameters:
+        relevant_docs (set): Set of relevant document IDs.
+        retrieved_docs (list): List of retrieved document IDs in ranked order.
+        k (int): Number of top results to consider.
+    Returns:
+        float: Precision@K score.
+    """
+    retrieved_at_k = retrieved_docs[:k]
+    intersection = set(retrieved_at_k) & set(relevant_docs)
+    return len(intersection) / float(k)
+
+
+def calc_recall_at_k(relevant_docs, retrieved_docs, k):
+    """
+    Compute Recall@K.
+    Parameters:
+        relevant_docs (set): Set of relevant document IDs.
+        retrieved_docs (list): List of retrieved document IDs in ranked order.
+        k (int): Number of top results to consider.
+    Returns:
+        float: Recall@K score.
+    """
+    retrieved_at_k = retrieved_docs[:k]
+    intersection = set(retrieved_at_k) & set(relevant_docs)
+    return len(intersection) / len(relevant_docs)
+
+
+def calc_ndcg(relevant_docs, retrieved_docs, k, score_type='rank',  retrieved_distances=None):
+    if len(retrieved_docs) <2:
+        return 0.00
+    y_true = np.array([[1 if doc in relevant_docs else 0 for doc in retrieved_docs]])
+    if score_type == 'rank':
+        y_scores = np.array([[1 / (rank + 1) for rank in range(len(retrieved_docs))]])
+    elif score_type == 'distance':
+        y_scores = np.array([[1 - dist for dist in retrieved_distances]])
+    ndcg = ndcg_score(y_true, y_scores, k=k)
+    return ndcg
+
+def calc_reciprocal_rank(relevant_docs, retrieved_docs):
+    """
+    Compute Reciprocal Rank (RR).
+    Parameters:
+        relevant_docs (set): Set of relevant document IDs.
+        retrieved_docs (list): List of retrieved document IDs in ranked order.
+    Returns:
+        float: MRR score.
+        Can be used to compute mean reciprocal rank for number of queries Q
+    """
+    for rank, doc in enumerate(retrieved_docs, start=1):
+        if doc in relevant_docs:
+            return 1 / rank
+    return 0.0
+
+
+def calc_average_precision(relevant_docs, retrieved_docs, k):
+    """
+    Compute Average Precision (AP).
+    Parameters:
+        relevant_docs (list): List of relevant document IDs.
+        retrieved_docs (list): List of retrieved document IDs in ranked order.
+        k: average precision from 1 to k 
+    Returns:
+        float: AP score.
+        Can be used to calculate mean average precision for number of queries Q
+    """
+    if len(retrieved_docs) < 2:
+        return 0.0
+
+    total_precision = 0.0
+
+    for i in range(1, len(retrieved_docs)+1): 
+        precision = calc_precision_at_k(relevant_docs, retrieved_docs, k=i)
+        total_precision += precision
+
+    if k > len(retrieved_docs):
+        print(f"k is higher than retrieval {len(retrieved_docs)}")
+
+    elif k < len(retrieved_docs):
+        print(f"k is lower than retrieval {len(retrieved_docs)}")
+
+    average_precision = total_precision / float(k)
+
+    return average_precision
+
+
+def format_judge_response(answer):
+    try:
+        formatted_answer = json.loads(answer[0]['generated_text'])
+    except:
+        try:
+            print("cleaning json")
+            formatted_answer = json.loads(answer[0]['generated_text'].replace("\n",""))
+        except:
+            try:
+                print("trying another way")
+                formatted_answer = json.loads(re.sub(r'```json|```', '', answer[0]['generated_text'].replace("\n","")).strip())
+            except:
+                formatted_answer = answer[0]['generated_text']
+    return formatted_answer
+
+
+
+def calc_jaccard_index(text_a, text_b):
+    try:
+        text_a = text_a.lower()
+        text_b = text_b.lower()
+        # Tokenize into sets of words
+        set_a = set(text_a.split())
+        set_b = set(text_b.split())
+        intersection = len(set_a & set_b)
+        union = len(set_a | set_b)
+        return intersection / union
+    except:
+        return 0.00
+
+def calc_overlap_coefficient(text_a, text_b):
+    try:
+        text_a = text_a.lower()
+        text_b = text_b.lower()
+        set1, set2 = set(text_a.split()), set(text_b.split())
+        intersection = len(set1 & set2)
+        min_length = min(len(set1), len(set2))
+        return intersection / min_length
+    except:
+        return 0.00
+
+
+
+def run_traditional_eval(query_id, query, relevant_docs, retrieved_docs, retrieved_distances, retrieved_texts, relevant_texts, k):
+    row = {'query_id': query_id}
+    row['query'] = query
+    # calcuate traditional IR metrics
+    precision = calc_precision_at_k(relevant_docs, retrieved_docs, k)
+    recall = calc_recall_at_k(relevant_docs, retrieved_docs, k)
+    ndcg = calc_ndcg(relevant_docs, retrieved_docs,score_type='rank',retrieved_distances=retrieved_distances, k=k)
+    reciprocal_rank = calc_reciprocal_rank(relevant_docs, retrieved_docs)
+    average_precision = calc_average_precision(relevant_docs, retrieved_docs, k=k)
+    jaccard_indices = [calc_jaccard_index(query, text) for text in retrieved_texts]
+    overlap_coefficients = [calc_overlap_coefficient(query, text) for text in retrieved_texts]
+    query_overlap_coefficients = np.mean([calc_overlap_coefficient(query, text) for text in relevant_texts])
+
+    # store in row
+    row['retrieved_ids'] = retrieved_docs
+    row['relevant_docs'] = relevant_docs
+    row[f'precision@{k}'] = precision
+    row[f'recall@{k}'] = recall
+    row[f'ndcg@{k}'] = ndcg
+    row['reciprocal_rank'] = reciprocal_rank
+    row['average_precision'] = average_precision
+    row['jaccard_indices'] = jaccard_indices
+    row['overlap_coefficients'] = overlap_coefficients
+    row['query_overlap_coefficients'] = query_overlap_coefficients
+
+
+    return row

--- a/evaluation_pipeline/pipeline_utils/non_ml_comparison.py
+++ b/evaluation_pipeline/pipeline_utils/non_ml_comparison.py
@@ -1,0 +1,543 @@
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity, euclidean_distances
+from rank_bm25 import BM25Okapi
+from nltk.tokenize import word_tokenize
+import pandas as pd
+import numpy as np
+from urllib.parse import urlparse, urlunparse
+import nltk
+from pipeline_utils.features import process_history
+from rank_bm25 import BM25Okapi
+import argparse
+import pandas as pd
+import re
+from urllib.parse import unquote
+import gc
+from pipeline_utils.utils import build_model_run_details_dict, convert_dict_to_df
+from collections import defaultdict
+
+
+
+
+
+def normalize_url(url):
+    parsed = urlparse(url)
+    # Remove fragments and queries, keep scheme + netloc + path
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, '', '', ''))
+
+
+def get_relevant_docs(history, url_type, query_file_path):
+    golden_queries = pd.read_csv(query_file_path)
+
+    if 'query' not in golden_queries.columns:
+        golden_queries['query'] = golden_queries['search_query']
+
+    golden_queries['norm_url'] = golden_queries['url'].apply(normalize_url)
+    golden_queries = golden_queries[['query','url','norm_url']]
+
+    relevant_docs = pd.merge(
+        golden_queries,
+        history,
+        on=url_type,
+        how='inner',
+        suffixes=('_left', '_right')
+    )
+
+
+    relevant_docs = relevant_docs.rename(columns={
+         "url_left": "url",
+         "norm_url_left": "norm_url",
+    })
+
+
+    relevant_docs = relevant_docs[['query', 'url', 'norm_url', 'index_col', 'title', 'description', 'combined_text']]
+
+
+    golden_query_df = pd.DataFrame(relevant_docs.groupby('query').agg({
+            'url': list,
+            'norm_url': list,
+            'index_col': list,
+            'title': list,
+            'description': list,
+            'combined_text': list,
+        }
+    )).reset_index()
+
+    return golden_query_df
+
+
+
+def process_data(history_file_path, model_run_details):
+
+    processed_history, processed_history_file_path = process_history(
+        row_limit=model_run_details['row_limit'],
+        history_file_path=history_file_path,
+        preprocess=model_run_details['preprocess'],
+        features=model_run_details['features'],
+    )
+
+    processed_history['index_col'] = processed_history.index
+
+    return processed_history
+
+def create_ground_truth(golden_query_df, url_type):
+
+    # Each query_id maps to a dict of lists
+    ground_truth_dict = defaultdict(lambda: {
+        "doc_ids": [],
+        f"{url_type}s": [],
+        "combined_texts": []
+    })
+
+    for query, index_col, url, combined_text in zip(
+        golden_query_df["query"],
+        golden_query_df["index_col"],
+        golden_query_df[f"{url_type}"],
+        golden_query_df["combined_text"],
+        ):
+        ground_truth_dict[query]["doc_ids"].extend(index_col)
+        ground_truth_dict[query][f"{url_type}s"].extend(url)
+        ground_truth_dict[query]["combined_texts"].extend(combined_text)
+
+    return ground_truth_dict
+
+
+# TF-IDF Retrieval
+def tfidf_retrieval(history,  golden_query_df, model_run_details):
+
+    vectorizer = TfidfVectorizer()
+    tfidf_matrix = vectorizer.fit_transform(history["combined_text"])
+    results = {}
+
+    for i, row in golden_query_df.iterrows():
+
+        query_matrix = vectorizer.transform(
+            [row['query']]
+            )
+
+        if model_run_details['distance_measure'] =='cosine':
+
+            similarities = cosine_similarity(
+                query_matrix,
+                tfidf_matrix).flatten()
+
+            distances = 1 - similarities
+
+            ranked_indices = similarities.argsort()[::-1][:model_run_details['k']]
+
+        elif model_run_details['distance_measure'] == 'L2':
+
+            distances = euclidean_distances(
+                query_matrix,
+                tfidf_matrix).flatten()
+
+            ranked_indices = distances.argsort()[:model_run_details['k']]
+
+
+        retrievals = [
+            {
+                "id": history.iloc[idx]["index_col"],  # Use original index from `history`
+                "title": history.iloc[idx]["title"],
+                "url": history.iloc[idx]["url"],
+                "combined_text": history.iloc[idx]["combined_text"],
+                "distance": distances[idx]
+            }
+            for idx in ranked_indices
+        ]
+        results[row['query']] = retrievals
+
+    return results
+
+# BM25 Retrieval
+def bm25_retrieval(history, golden_query_df, model_run_details):
+    nltk.download("punkt")
+
+    tokenized_corpus = [word_tokenize(
+        doc.lower()
+        ) for doc in history["combined_text"]]
+
+    bm25 = BM25Okapi(tokenized_corpus)
+    results = {}
+
+    for i, row in golden_query_df.iterrows():
+
+        tokenized_query = word_tokenize(
+            row['query'].lower()
+            )
+
+        scores = bm25.get_scores(tokenized_query)
+
+        ranked_indices = np.argsort(scores)[::-1][:model_run_details['k']]
+
+        retrievals = [
+            {
+                "id": history.iloc[idx]["index_col"],  # Use original index from `history`
+                "title": history.iloc[idx]["title"],
+                "url": history.iloc[idx]["url"],
+                "combined_text": history.iloc[idx]["combined_text"],
+                "distance": scores[idx]
+            }
+            for idx in ranked_indices
+        ]
+        results[row['query']] =  retrievals
+
+    return results
+
+
+def exact_match_retrieval(history, golden_query_df, model_run_details):
+    """
+    Exact Match Retrieval: Matches documents where the query terms exactly match the document terms.
+    
+    Args:
+        history (pd.DataFrame): DataFrame containing the documents with `combined_text` and metadata (e.g., title, URL, index_col).
+        unique_search_query_df (pd.DataFrame): DataFrame with search queries and associated metadata.
+        top_k (int): Number of top results to retrieve for each query.
+
+    Returns:
+        list[dict]: A list of dictionaries containing the retrieval results for each query.
+    """
+    results = {}
+
+    for i, row in golden_query_df.iterrows():
+
+        query = row['query'].lower()
+
+        # Filter documents in the history DataFrame where `combined_text` contains the exact query terms
+        matches = history[history['combined_text'].str.contains(rf'\b{query}\b', case=False, na=False)]
+
+        # Limit to top_k results
+        matches = matches.head(
+            model_run_details['k']
+            )
+
+        # Format the retrieval results
+        retrievals = [
+            {
+                "id": doc["index_col"],
+                "title": doc["title"],
+                "url": doc["url"],
+                "combined_text": doc["combined_text"],
+                "distance": 0  # Exact match has no distance concept, so we use 0 as a placeholder
+            }
+            for _, doc in matches.iterrows()
+        ]
+
+        results[row['query']] =  retrievals
+
+    return results
+
+
+def exact_match_overlap(history, golden_query_df, model_run_details):
+    results = {}
+    for i, row in golden_query_df.iterrows():
+        query_terms = set(row['query'].lower().split())  # Convert query to a set of words
+
+        history['overlap_count'] = history['combined_text'].apply(
+            lambda text: len(query_terms.intersection(set(str(text).lower().split())))
+        )
+
+        k = model_run_details['k']
+        print(k)
+
+        # Keep only rows where there is at least one matching word, then sort by overlap & frecency
+        matches = history[history['overlap_count'] > 0].sort_values(by=['overlap_count', 'frecency'], ascending=[False, False])[:k]
+        retrievals = [
+            {
+                "id": doc["index_col"],
+                "title": doc["title"],
+                "url": doc["url"],
+                "combined_text": doc["combined_text"],
+                "distance": 0  # Exact match has no distance concept, so we use 0 as a placeholder
+            }
+            for _, doc in matches.iterrows()
+        ]
+
+        results[row['query']] =  retrievals
+
+        return results
+    
+
+def exact_match_terms_retrieval_frecency(history, golden_query_df, model_run_details):
+    """
+    Exact Match Retrieval: Matches documents where the query terms exactly match the document terms.
+    
+    Args:
+        history (pd.DataFrame): DataFrame containing the documents with `combined_text` and metadata (e.g., title, URL, index_col).
+        unique_search_query_df (pd.DataFrame): DataFrame with search queries and associated metadata.
+        top_k (int): Number of top results to retrieve for each query.
+
+    Returns:
+        list[dict]: A list of dictionaries containing the retrieval results for each query.
+    """
+    results = {}
+
+    for i, row in golden_query_df.iterrows():
+        query = row['query'].lower()
+        query_terms = query.split()  # Split query into words
+        pattern = r"\b(" + "|".join(query_terms) + r")\b"
+        # Escape regex special characters to ensure plain text search
+        escaped_pattern = re.escape(pattern)
+        matches = history[history['combined_text'].str.contains(escaped_pattern, case=False, na=False,regex=True)].sort_values(by='frecency', ascending=False)
+
+        # Limit to top_k results
+        matches = matches.head(model_run_details['k'])
+        # Format the retrieval results
+        retrievals = [
+            {
+                "id": doc["index_col"],
+                "title": doc["title"],
+                "url": doc["url"],
+                "combined_text": doc["combined_text"],
+                "distance": 0  # Exact match has no distance concept, so we use 0 as a placeholder
+            }
+            for _, doc in matches.iterrows()
+        ]
+
+        results[row['query']] =  retrievals
+
+    return results
+
+
+def fixup_uri_spec(url: str, match_behavior: str) -> str:
+    """Normalize URL by removing prefixes and unescaping."""
+    url = unquote(url)  # Decode URL-encoded characters
+
+    # Remove common URL prefixes
+    if url.startswith("http://"):
+        url = url[7:]
+    elif url.startswith("https://"):
+        url = url[8:]
+    elif url.startswith("ftp://"):
+        url = url[6:]
+
+    if match_behavior == "MATCH_ANYWHERE_UNMODIFIED":
+        return url
+
+    return url
+
+
+def find_anywhere(token: str, source: str) -> bool:
+    """Finds token anywhere in the source string (case-insensitive)."""
+    return token.lower() in  str(source).lower()  # Convert NaN/float to string
+
+
+def find_on_boundary(token: str, source: str) -> bool:
+    """Finds token only on word boundaries (case-insensitive)."""
+    return bool(re.search(r'\b' + re.escape(token) + r'\b', str(source), re.IGNORECASE))
+
+
+def get_search_function(match_behavior: str):
+    """Returns the appropriate search function."""
+    if match_behavior in ["MATCH_ANYWHERE", "MATCH_ANYWHERE_UNMODIFIED"]:
+        return find_anywhere
+    return find_on_boundary
+
+
+def match_autocomplete_pandas(df, search_string, match_behavior,  k):
+    """
+    Searches a Pandas DataFrame of moz_places using filtering and matching logic.
+
+    Args:
+        df: Pandas DataFrame containing the browser history.
+        search_string (str): User's search input.
+        match_behavior (str): Matching type (MATCH_ANYWHERE, MATCH_BOUNDARY).
+
+
+    Returns:
+        Filtered Pandas DataFrame with matching results.
+    """
+    search_tokens = search_string.lower().split()
+    search_function = get_search_function(match_behavior)
+
+    # Normalize URLs
+    df["fixed_url"] = df["url"].apply(lambda x: fixup_uri_spec(x, match_behavior))
+    if 'id' not in df.columns:
+        df['id'] = df.index
+    if 'frecency' not in df.columns:
+        df['frecency'] = 0
+
+
+    # Apply search logic
+    def matches(row):
+        return all(
+            search_function(token, row["fixed_url"]) or
+            search_function(token, row["title"])
+            for token in search_tokens
+        )
+
+    result_df = df[df.apply(matches, axis=1)][["id", "url", "title", "combined_text","frecency"]].copy()
+
+    return result_df.sort_values(by=["frecency", "id"], ascending=[False, False]).head(k)
+
+
+
+def current_suggest_match(history, golden_query_df, model_run_details, match_behavior):
+    results = {}
+    for i, row in golden_query_df.iterrows():
+        search_query = row['query']
+        results_df = match_autocomplete_pandas(history, search_string=search_query, match_behavior=match_behavior, k=model_run_details['k'])
+        retrievals = [
+            {
+                "id": doc["id"],
+                "title": doc["title"],
+                "url": doc["url"],
+                "combined_text": doc["combined_text"],
+                "distance": 0  # Exact match has no distance concept, so we use 0 as a placeholder
+            }
+            for _, doc in results_df.iterrows()
+        ]
+        results[row['query']] =  retrievals
+    return results
+
+
+
+def save_results(retrieval_results, model_run_details, ground_truth, norm_ground_truth, save_dir):
+
+    result_df = convert_dict_to_df(
+        retrieval_results,
+        ground_truth,
+        norm_ground_truth,
+        model_run_details
+    )
+
+    result_df['model_run_details'] = [model_run_details] * len(result_df)
+
+    save_file_name = f'{save_dir}'+model_run_details['retrieval_file_name']+'.csv'
+
+    result_df.to_csv(save_file_name)
+
+    return save_file_name
+
+
+def non_ml_baseline_pipeline(history_file_path, save_dir, query_file_path, model_run_details):
+
+    history = process_data(
+        history_file_path,
+        model_run_details
+    )
+
+
+    golden_query_df = get_relevant_docs(
+        history,
+        url_type='url',
+        query_file_path=query_file_path
+    )
+
+
+    ground_truth = create_ground_truth(
+        golden_query_df,
+        url_type='url'
+    )
+
+
+    norm_golden_query_df = get_relevant_docs(
+        history,
+        url_type='norm_url',
+        query_file_path=query_file_path
+    )
+
+
+    norm_ground_truth = create_ground_truth(
+        norm_golden_query_df,
+        url_type='norm_url'
+    )
+
+    tfidf_results = tfidf_retrieval(
+        history,
+        golden_query_df,
+        model_run_details
+    )
+
+
+    bm25_results = bm25_retrieval(
+        history,
+        golden_query_df,
+        model_run_details
+    )
+
+
+    exact_match_results = exact_match_retrieval(
+        history,
+        golden_query_df,
+        model_run_details
+    )
+
+    exact_match_results_frecency = exact_match_terms_retrieval_frecency(
+        history,
+        golden_query_df,
+        model_run_details
+    )
+
+
+    # current suggest implementation
+    suggest_match_anywhere_results = current_suggest_match(
+        history,
+        golden_query_df,
+        model_run_details,
+        match_behavior='MATCH_ANYWHERE'
+    )
+
+
+    suggest_match_boundary_results = current_suggest_match(
+        history,
+        golden_query_df,
+        model_run_details,
+        match_behavior='MATCH_BOUNDARY'
+    )
+
+    exact_match_overlap_results = exact_match_overlap(
+        history,
+        golden_query_df,
+        model_run_details
+    )
+
+
+    all_results = [tfidf_results,
+                   bm25_results,
+                   exact_match_results,
+                   exact_match_results_frecency,
+                   suggest_match_anywhere_results,
+                   suggest_match_boundary_results,
+                   exact_match_overlap_results
+                   ]
+
+    # retrieval
+    model_names = ['tfidf', 'bm25','exact_match','exact_match_frecency','suggest_match_anywhere','suggest_match_boundary','exact_match_overlap']
+
+    results_dict = dict(zip(model_names, all_results))
+
+    features = model_run_details['features']
+    preprocess = model_run_details['preprocess']
+    row_limit = model_run_details['row_limit']
+    k=model_run_details['k']
+
+    # save results
+    saved_files = []
+    for model_name, retrieval_results in results_dict.items():
+
+        model_run_details = build_model_run_details_dict(history_file_path, model_name, features, quantized_model=False, distance_measure='', pooling='', preprocess=preprocess, row_limit=row_limit, k=k)
+        model_run_details['embedding_dim'] = 0
+
+
+        save_file_name = save_results(
+            retrieval_results,
+            model_run_details,
+            ground_truth,
+            norm_ground_truth,
+            save_dir
+        )
+        saved_files.append(save_file_name)
+
+    del results_dict
+    del history
+    del golden_query_df
+    gc.collect()
+    return saved_files
+
+
+def main(history_file_path, save_dir, query_file_path, model_run_details):
+    saved_files = non_ml_baseline_pipeline(history_file_path, save_dir, query_file_path, model_run_details)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation_pipeline/pipeline_utils/retrieval.py
+++ b/evaluation_pipeline/pipeline_utils/retrieval.py
@@ -1,0 +1,251 @@
+import time
+import pandas as pd
+import os
+import gc
+from collections import defaultdict
+import yaml
+from pipeline_utils.feature_extractor_optimized import FeatureExtractor
+from pipeline_utils.utils import log_performance,  serialize_f32, clean_text, convert_dict_to_df, build_model_run_details_dict
+
+with open("evaluation_pipeline/model_config.yml", "r") as f:
+    config = yaml.safe_load(f)
+
+
+# retrieval
+@log_performance
+def query_and_result(fe, prefix, query, db, model_run_details):
+    if model_run_details['preprocess']:
+        query_to_embed = clean_text(query)
+    else:
+        query_to_embed = query
+
+    query_to_embed =  prefix + query_to_embed
+
+    distance_measure = model_run_details['distance_measure']
+
+    query_embedding = fe.get_embedding(query_to_embed)
+
+    embedding_dim = len(query_embedding)
+
+    binary_quantization = model_run_details['binary_quantization']
+    if binary_quantization:
+        coarse_filter = model_run_details['binary_quantization_coarse_filter']
+        print(coarse_filter)
+
+        # this is not working yet 
+        rows = db.execute(
+            f'''
+            with coarse_matches as (
+            SELECT a.rowid,
+            a.embedding,
+            b.title,
+            b.description,
+            b.url,
+            b.norm_url,
+            b.combined_text
+
+            FROM vec_items_{model_run_details['model_name_normalized']} a
+    
+            inner join search_data b
+            on a.rowid = b.rowid
+    
+            WHERE
+            embedding_coarse match vec_quantize_binary(?)
+            and b.url not like '%google.com/search?%'
+    
+            ORDER BY DISTANCE
+            LIMIT {coarse_filter}
+        ) coarse_matches
+    
+        SELECT rowid,
+            title,
+            description,
+            url,
+            norm_url,
+            combined_text,
+            vec_distance_{distance_measure}(embedding, ?) AS {distance_measure}_distance
+    
+        FROM coarse_matches
+    
+        ORDER BY {distance_measure}_distance
+
+        LIMIT {model_run_details['k']}
+
+            ''',
+         [serialize_f32(query_embedding), serialize_f32(query_embedding)],
+         ).fetchall()
+
+    else:
+
+         # NO BINARY QUANTIZATIOn
+         rows = db.execute(
+         f"""
+          SELECT
+             a.rowid,
+             b.title,
+             b.description,
+             b.url,
+             b.norm_url,
+             b.combined_text,
+             vec_distance_{distance_measure}(embedding, ?) AS {distance_measure}_distance
+
+           FROM vec_items_{model_run_details['model_name_normalized']} a
+        
+           inner join search_data b
+           on a.rowid = b.rowid
+        
+           where b.url not like '%google.com/search?%'
+           ORDER BY {distance_measure}_distance
+           LIMIT {model_run_details['k']}
+         """,
+         [serialize_f32(query_embedding)],
+         ).fetchall()
+
+
+    results = []
+
+    for row in rows:
+        results.append({
+            "id": row[0],
+            "title": row[1],
+            "description": row[2],
+            "url": row[3],
+            "norm_url": row[4],
+            "combined_text": row[5],
+            "distance": row[6],
+        })
+
+    return results, embedding_dim
+
+def get_relevant_doc_ids(db, url_type, input_dir):
+    # join to search query to get doc ID for ground truth URL
+    results = db.execute(
+        f'''SELECT a.query,
+          b.{url_type},
+          b.rowid,
+          b.combined_text
+
+        FROM ground_truth a
+
+        left join search_data b
+        on a.{url_type} = b.{url_type}
+    '''
+    ).fetchall()
+
+    # Each query_id maps to a dict of lists
+    ground_truth_dict = defaultdict(lambda: {
+        "doc_ids": [],
+        f"{url_type}s": [],
+        "combined_texts": []
+    })
+
+    for query, url, id_, combined_text in results:
+        ground_truth_dict[query]["doc_ids"].append(id_)
+        ground_truth_dict[query][f"{url_type}s"].append(url)
+        ground_truth_dict[query]["combined_texts"].append(combined_text)
+
+
+    ground_truth_df = pd.DataFrame.from_dict(ground_truth_dict).T
+    ground_truth_df.to_csv(f'{input_dir}ground_truth_with_metadata_{url_type}.csv')
+
+    return ground_truth_dict
+
+
+@log_performance
+def run_retrieval(fe, prefix, queries, db, model_run_details):
+
+    print("running retreival")
+    retreival_dict = {}
+
+    for query in queries:
+        results, embedding_dim = query_and_result(
+            fe,
+            prefix,
+            query,
+            db=db,
+            model_run_details=model_run_details
+        )
+
+        retreival_dict[query] = results
+
+    return retreival_dict, embedding_dim
+
+
+
+def retrieval_pipeline(model_run_details, queries, db, save_result_dir, input_dir):
+    process_start = time.time()
+
+
+    fe = FeatureExtractor(
+        model_name=model_run_details['model_name'],
+        quantized=model_run_details['quantized'],
+        pooling=model_run_details['pooling'],
+    )
+
+    # run retrieval
+    models_parameters = config["models"][model_run_details['model_name']]
+    prefix = models_parameters['prefix_query']
+    print(f"Using prefix: {prefix}")
+
+    retrieval_dict, embedding_dim = run_retrieval(
+        fe,
+        prefix,
+        queries,
+        db,
+        model_run_details
+    )
+
+    ground_truth_dict = get_relevant_doc_ids(
+        db,
+        url_type='url',
+        input_dir=input_dir,
+    )
+
+    norm_ground_truth_dict = get_relevant_doc_ids(
+        db,
+        url_type='norm_url',
+         input_dir=input_dir,
+    )
+
+    # reshape to capture metadata
+    retreival_df = convert_dict_to_df(
+                            retrieval_dict,
+                            ground_truth_dict,
+                            norm_ground_truth_dict,
+                            model_run_details
+                            )
+
+    model_run_details['embedding_dim'] = embedding_dim
+
+    retreival_df['model_run_details'] = [model_run_details] * len(retreival_df)
+
+    # save to csv
+    retrieval_save_path = f"{save_result_dir}{model_run_details['retrieval_file_name']}_results.csv"
+
+    if not os.path.exists(save_result_dir):
+        os.makedirs(save_result_dir)
+        print(f"Directory created: {save_result_dir}")
+
+    retreival_df.to_csv(
+        retrieval_save_path,
+        index=False
+    )
+
+    process_end = time.time()
+
+    print(f"Process took {process_end - process_start} seconds")
+
+    # memory cleanup
+    del fe
+    del db
+    del retreival_df
+    gc.collect()
+    return retrieval_save_path
+
+
+def main(model_run_details, queries, db, save_result_dir):
+    retrieval_pipeline(model_run_details, queries, db, save_result_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation_pipeline/pipeline_utils/utils.py
+++ b/evaluation_pipeline/pipeline_utils/utils.py
@@ -1,0 +1,269 @@
+from urllib.parse import urlparse, urlunparse
+import tracemalloc
+import logging
+import time
+from typing import List
+import struct
+import tldextract
+from urllib.parse import urlparse, unquote
+import sqlite3
+import ast
+import pandas as pd
+import re
+import unicodedata
+
+def clean_text(text):
+    """Lowercases, removes extra spaces, special characters, and normalizes Unicode."""
+    if not isinstance(text, str):
+        return ""
+    
+    text = text.lower().strip()  # Convert to lowercase & trim spaces
+    text = re.sub(r'<.*?>', '', text)  # Remove HTML tags
+    text = re.sub(r'[\t\n\r]', ' ', text)  # Replace newlines/tabs with space
+    text = re.sub(r'\s+', ' ', text)  # Replace multiple spaces with single space
+    text = unicodedata.normalize("NFKD", text)  # Normalize Unicode
+    return text
+
+
+def normalize_url(url):
+    parsed = urlparse(url)
+    # Remove fragments and queries, keep scheme + netloc + path
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, '', '', ''))
+
+def preprocess_url(url, keep_subdomain=False):
+    """Extracts and normalizes domain from a URL."""
+    parsed_url = urlparse(url)
+    domain_parts = tldextract.extract(parsed_url.netloc)
+
+    # Extract root domain or full domain (subdomain.example.com)
+    domain = f"{domain_parts.domain}.{domain_parts.suffix}" if not keep_subdomain else parsed_url.netloc
+    return unquote(domain)  # Decode URL encoding (e.g., %20 → " ")
+
+
+def log_performance(func):
+    def wrapper(*args, **kwargs):
+        start_time = time.time()
+        tracemalloc.start()
+        result = func(*args, **kwargs)
+        current, peak = tracemalloc.get_traced_memory()
+        end_time = time.time()
+        logging.info(f"Function: {func.__name__}")
+        logging.info(f"Execution Time: {end_time - start_time:.2f} seconds")
+        logging.info(f"Current Memory Usage: {current / 10**6:.2f} MB")
+        logging.info(f"Peak Memory Usage: {peak / 10**6:.2f} MB")
+        tracemalloc.stop()
+        return result
+    return wrapper
+
+
+def format_size(size_in_bytes):
+    """Convert bytes to a human-readable format (KB, MB, GB, etc.)."""
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+        if size_in_bytes < 1024:
+            return f"{size_in_bytes:.2f} {unit}"
+        size_in_bytes /= 1024
+
+
+def serialize_f32(vector: List[float]) -> bytes:
+    """serializes a list of floats into a compact "raw bytes" format"""
+    return struct.pack("%sf" % len(vector), *vector)
+
+
+
+def create_ground_truth(history, query_ids):
+    queries = []
+    relevant_ids = []
+    for query in history['search_query'].unique():
+        query_id = query_ids[query]
+        queries.append(query_id)
+        ground_truths = []
+        for i, row in history.iterrows():
+            relevant = 1 if query == row['search_query'] else 0
+            if relevant == 1:
+                ground_truths.append(int(i))
+        relevant_ids.append(ground_truths)
+
+    return dict(zip(queries, relevant_ids))
+
+
+
+def get_table_size(connection, table_name):
+    """Get the approximate size of a table in SQLite."""
+    with connection:
+        cursor = connection.cursor()
+        # Get page size and page count
+        cursor.execute("PRAGMA page_count;")
+        page_count = cursor.fetchone()[0]
+
+        cursor.execute("PRAGMA page_size;")
+        page_size = cursor.fetchone()[0]
+        
+        total_db_size = page_count * page_size
+
+        # If dbstat is available, use it for more precision
+        try:
+            cursor.execute(f"""
+                SELECT SUM(pgsize) AS table_size
+                FROM dbstat
+                WHERE name = ?;
+            """, (table_name,))
+            result = cursor.fetchone()
+            if result and result[0]:
+                return result[0]
+        except sqlite3.DatabaseError:
+            print("dbstat is not available; estimating based on database size.")
+
+        # Fallback to database size as an estimate
+        return total_db_size
+
+
+
+
+def convert_to_list(value):
+    if isinstance(value, str):
+        value = value.replace('np.int64(', '').replace(')', '')
+        value = value.replace('np.float64(', '').replace(')', '')
+        return ast.literal_eval(value)
+    return value
+
+
+
+def get_combined_texts_uniform_k(df, k):
+    # Identify retrieval columns and sort them numerically
+    retrieval_cols = sorted(
+        [col for col in df.columns if 'retrieval_' in col and '_combined_text' in col],
+        key=lambda x: int(x.split('_')[1])
+    )
+
+    # Extract relevant retrieval columns as a NumPy array
+    retrieval_matrix = df[retrieval_cols].to_numpy()
+
+    # Slice the matrix up to `k` columns for all rows
+    sliced_matrix = retrieval_matrix[:, :k]
+
+    # Convert to a list of lists
+    result = sliced_matrix.tolist()
+    return result
+
+
+def convert_dict_to_df(retrieval_dict, ground_truth, norm_ground_truth, model_run_details):
+
+    rows = []
+
+    for query, retrievals in retrieval_dict.items():
+        # Flatten each retrieval into a single row with column names based on retrieval index
+        row = {'query': query}
+        retrieved_ids = []  # List to collect all retrieved IDs
+        retrieved_distances = [] # collect the distances
+        for i, retrieval in enumerate(retrievals, start=1):
+            row[f'retrieval_{i}_id'] = retrieval.get('id')
+            row[f'retrieval_{i}_title'] = retrieval.get('title')
+            row[f'retrieval_{i}_url'] = retrieval.get('url')
+            row[f'retrieval_{i}_combined_text'] = retrieval.get('combined_text')
+            row[f'retrieval_{i}_distance'] = retrieval.get('distance')
+            retrieved_ids.append(retrieval.get('id'))
+            retrieved_distances.append(retrieval.get('distance'))
+
+        row['retrieved_ids'] = retrieved_ids
+        row['retrieved_distances'] = retrieved_distances
+        row['model_name'] = model_run_details['model_name']
+        row['relevant_docs'] = ground_truth[query]['doc_ids']
+        row['relevant_urls'] = ground_truth[query]['urls']
+        row['relevant_combined_text'] = ground_truth[query]['combined_texts']
+        row['norm_relevant_docs'] = norm_ground_truth[query]['doc_ids']
+        row['norm_relevant_urls'] = norm_ground_truth[query]['norm_urls']
+        row['norm_relevant_combined_text'] = norm_ground_truth[query]['combined_texts']
+        row['k'] = model_run_details['k']
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+
+    return df
+
+
+def build_model_run_details_dict(history_file_path, model_name, features, quantized_model, distance_measure, pooling, preprocess, row_limit, k, binary_quantization=False, binary_quantization_coarse_filter=100):
+
+    dataset = history_file_path.split('/')[-1].replace('.csv','')
+
+    model_name_normalized = model_name.replace("/","_").replace("-","_").replace(".","_")
+
+    feature_string = "_".join(features)
+
+    suffix = '_quantized' * quantized_model
+    binary_quantization_suffix = '_binary_quantized' * binary_quantization
+    model_run_details  = {'model_name': model_name,
+                          'model_name_normalized': model_name_normalized,
+                          'quantized': quantized_model,
+                          'suffix': suffix,
+                          'distance_measure': distance_measure,
+                          'pooling': pooling,
+                          'row_limit': row_limit,
+                          'features': features,
+                          'feature_string': feature_string,
+                          'preprocess': preprocess,
+                          'k': k,
+                          'embedding_file_name': f"{dataset}_{model_name_normalized}_{suffix}_{pooling}_{distance_measure}_{feature_string}_{preprocess*'preprocess'}_{row_limit}",
+                          'retrieval_file_name': f"{dataset}_{model_name_normalized}_{suffix}_{pooling}_{distance_measure}_{feature_string}_{preprocess*'preprocess'}__top{k}_{row_limit}{binary_quantization_suffix}",
+                          'dataset': dataset,
+                          'binary_quantization': binary_quantization,
+                          'binary_quantization_coarse_filter':binary_quantization_coarse_filter
+                           }
+
+    return model_run_details
+
+
+
+
+def plot_retrieval(file_path):
+     import pandas as pd
+     import matplotlib.pyplot as plt
+     import textwrap
+
+     df = pd.read_csv(file_path)
+     
+     wrapped_labels = ["\n".join(textwrap.wrap(q, width=20)) for q in df["query"]]
+     
+     # Dynamically combine all retrieval_*_url columns into one
+     retrieval_url_columns = [col for col in df.columns if "retrieval_" in col and "_url" in col]
+     df["retrieved_urls"] = df[retrieval_url_columns].apply(lambda row: [url for url in row if pd.notna(url)], axis=1)
+     
+     retrieval_combined_text_columns = [col for col in df.columns if "retrieval_" in col and "_combined_text" in col]
+     df["retrieved_texts"] = df[retrieval_combined_text_columns].apply(lambda row: [combined_text for combined_text in row if pd.notna(combined_text)], axis=1)
+     
+     # Split queries into two halves
+     mid_index = len(df) // 2
+     df1 = df.iloc[:mid_index].reset_index(drop=True)  # First half
+     df2 = df.iloc[mid_index:].reset_index(drop=True)  # Second half
+     
+     # Create the visualization with two subplots
+     fig, axes = plt.subplots(ncols=2, figsize=(12, 5), sharex=True, sharey=False)
+     
+     for ax, df_subset in zip(axes, [df1, df2]):
+         ax.set_yticks(range(len(df_subset)))
+         ax.set_yticklabels(df_subset["query"], fontsize=8, ha="right")
+     
+         x_labels = ["Top 1", "Top 2", "Top 3"]
+         ax.set_xticks(range(3))
+         ax.set_xticklabels(x_labels, fontsize=8)
+     
+         box_height = 0.4
+         box_width = 0.3
+     
+         for i, row in df_subset.iterrows():
+             retrieved_urls = row["retrieved_urls"][:3]
+             relevant_urls = row.get("relevant_urls", [])  
+     
+             colors = ["blue" if url in relevant_urls else "gray" for url in retrieved_urls]
+     
+             for j, color in enumerate(colors):
+                 ax.add_patch(plt.Rectangle((j - box_width / 2, i - box_height / 2), box_width, box_height, color=color))
+     
+         ax.set_xlim(-0.5, 2.5)
+         ax.set_ylim(-0.5, len(df_subset) - 0.5)
+     
+     
+     # Set a shared title
+     fig.suptitle("Information Retrieval Results", fontsize=12)
+     plt.grid(False)
+     plt.tight_layout()
+     plt.show()

--- a/evaluation_pipeline/pipeline_utils/vector_db.py
+++ b/evaluation_pipeline/pipeline_utils/vector_db.py
@@ -1,0 +1,171 @@
+import pickle
+from pipeline_utils.utils import log_performance, normalize_url, serialize_f32
+import sqlite3
+import sqlite_vec
+import pandas as pd
+
+@log_performance
+def create_db():
+    # vector database (in memory)
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+
+    sqlite_version, vec_version = db.execute(
+        "select sqlite_version(), vec_version()"
+    ).fetchone()
+    print(f"sqlite_version={sqlite_version}, vec_version={vec_version}")
+    return db
+
+
+
+
+def load_history_in_db(db, browsing_history_path):
+    browsing_history = pd.read_csv(browsing_history_path)
+
+    db.execute('''CREATE TABLE IF NOT EXISTS search_data (
+        url TEXT,
+        title TEXT,
+        description TEXT,
+        combined_text TEXT,
+        norm_url TEXT
+        )
+        ''')
+    for idx, row in browsing_history.iterrows():
+            db.execute("""
+                INSERT INTO search_data (rowid, url, title, description, combined_text, norm_url)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (idx, row['url'], row['title'], row['description'],  row['combined_text'], row['norm_url'])
+            )
+    return db
+
+
+
+@log_performance
+def read_and_insert_embeddings_into_db(db, model_run_details):
+    print(model_run_details)
+
+    embedding_file_name = model_run_details['embedding_file_name']
+    binary_quantization = model_run_details['binary_quantization']
+
+    path = f"../data/embeddings_dict_{embedding_file_name}.pkl"
+    print(f"loading embeddings from {path}")
+
+    with open(path, "rb") as f:
+        embeddings_dict = pickle.load(f)
+
+    EMBEDDING_SIZE = embeddings_dict[model_run_details['model_name']][0].shape[0]
+
+    print("creating table")
+
+    items = []
+    for idx, vec in enumerate(embeddings_dict[model_run_details['model_name']]):
+        items.append((idx, serialize_f32(list(vec))))
+
+    if binary_quantization:
+
+        db.execute(f'''CREATE VIRTUAL TABLE all_vec_items_{model_run_details['model_name_normalized']} USING vec0(
+                   embedding float[{EMBEDDING_SIZE}]
+                   )
+            '''
+        )
+
+        db.executemany(f'''INSERT INTO all_vec_items_{model_run_details['model_name_normalized']}
+                    (rowid, embedding)
+                    VALUES (?, ?)
+                    ''',
+                    items
+        )
+
+        db.execute(f'''CREATE VIRTUAL TABLE vec_items_{model_run_details['model_name_normalized']} USING vec0(
+                   embedding float[{EMBEDDING_SIZE}],
+                   embedding_coarse bit[{EMBEDDING_SIZE}]
+                   )
+            '''
+        )
+
+        db.execute(f''' INSERT INTO vec_items_{model_run_details['model_name_normalized']}
+        SELECT rowid,
+                embedding,
+                vec_quantize_binary(embedding)
+        FROM all_vec_items_{model_run_details['model_name_normalized']}
+        '''
+        )
+
+    else:
+        db.execute(f'''CREATE VIRTUAL TABLE vec_items_{model_run_details['model_name_normalized']} USING vec0(
+                   embedding float[{EMBEDDING_SIZE}]
+                   )
+            '''
+        )
+
+        # Perform batch insertion into the vec0 table
+        db.executemany(f'''INSERT INTO vec_items_{model_run_details['model_name_normalized']}
+                    (rowid, embedding)
+                    VALUES (?, ?)
+                    ''',
+                    items
+        )
+
+
+    print("loaded succesfully")
+
+    db.commit()
+
+    return db
+
+
+def load_ground_truth_into_db(db, golden_df_file_path):
+    print("loading golden")
+    golden_df = pd.read_csv(golden_df_file_path)
+
+    if 'search_query' in golden_df.columns:
+        query_field_name = 'search_query'
+    else:
+        query_field_name = 'query'
+
+    golden_df['norm_url'] = golden_df['url'].apply(normalize_url)
+
+    golden_df['query'] = golden_df[query_field_name]
+
+    processed_golden_df_path = 'processed_golden_df.csv'
+
+    golden_df.to_csv(processed_golden_df_path)
+
+    queries = golden_df['query'].unique()
+
+    golden_df[['query', 'url','norm_url']].to_sql("ground_truth", db, if_exists="replace", index=True)
+    print("finished loading golden")
+
+    return queries, processed_golden_df_path
+
+
+def vector_db_pipeline(browsing_history_path, golden_df_file_path, model_run_details):
+    db = create_db()
+
+    load_history_in_db(
+        db,
+        browsing_history_path
+    )
+
+    read_and_insert_embeddings_into_db(
+        db,
+        model_run_details
+    )
+
+    queries, processed_golden_df_path = load_ground_truth_into_db(
+        db,
+        golden_df_file_path
+    )
+
+    return db, queries, processed_golden_df_path
+
+
+def main(browsing_history_path, golden_df_file_path, model_run_details):
+    vector_db_pipeline(browsing_history_path, golden_df_file_path, model_run_details)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/evaluation_pipeline/requirements.txt
+++ b/evaluation_pipeline/requirements.txt
@@ -12,3 +12,11 @@ wandb==0.19.3
 Requests==2.32.3
 torch==2.5.1
 transformers==4.46.3
+tldextract==5.1.3
+optimum==1.24.0
+onnx==1.17.0
+onnxruntime==1.20.1
+rank-bm25==0.2.2
+nltk==3.9.1
+python-dotenv==1.0.1
+wandb==0.19.6

--- a/evaluation_pipeline/run_config.yml
+++ b/evaluation_pipeline/run_config.yml
@@ -1,0 +1,45 @@
+# Input Data Paths
+input:
+  input_dir:  "/Users/rebeccahadi/Documents/search-your-history-poc/smart_search/"
+  history_file_path: "/Users/rebeccahadi/Documents/search-your-history-poc/smart_search/output.csv"
+  golden_df_file_path: "/Users/rebeccahadi/Documents/search-your-history-poc/smart_search/golden_query_set.csv"
+  history_row_limit: 10008
+
+# Output Directories
+output:
+  save_result_dir: "validation_sets/rebecca/results/"
+  save_eval_dir: "evaluation_results/"
+
+# Run Parameters
+model:
+  quantized_model: True
+  pooling: "mean"
+  preprocess_input: False
+  embeddings_already_exist: False
+
+
+model_names:
+  - "Xenova/all-MiniLM-L6-v2"
+  - "Xenova/all-MiniLM-L12-v2"
+  - "Xenova/multi-qa-MiniLM-L6-cos-v1"
+  - "Xenova/multi-qa-distilbert-cos-v1"
+  - "nomic-ai/nomic-embed-text-v1.5"
+  - "Xenova/all-mpnet-base-v2"
+  - "Xenova/paraphrase-mpnet-base-v2"
+  - "Xenova/paraphrase-multilingual-MiniLM-L12-v2"
+
+retrieval:
+  distance_measure: "cosine"
+  k: 3
+  features:
+    - "title"
+    - "description"
+  include_non_ml_baseline: True
+  binary_quantization: False  # True is not yet working
+
+
+evaluation:
+    llm_judge: False
+    log_to_wandb: False
+
+

--- a/evaluation_pipeline/run_evaluation_pipeline.py
+++ b/evaluation_pipeline/run_evaluation_pipeline.py
@@ -1,0 +1,153 @@
+import sys
+import os
+from pipeline_utils.utils import build_model_run_details_dict
+from pipeline_utils.features import feature_pipeline
+from pipeline_utils.vector_db import vector_db_pipeline
+from pipeline_utils.retrieval import retrieval_pipeline
+from pipeline_utils.non_ml_comparison import non_ml_baseline_pipeline
+from pipeline_utils.evaluation import evaluation_pipeline
+import yaml
+import gc
+import multiprocessing
+from pipeline_utils.utils import log_performance
+
+@log_performance
+def full_pipeline(config_path, model_name):
+
+    print(f"Running model {model_name}:  PID: {os.getpid()}")
+
+    # Load the config file
+    with open(config_path, "r") as file:
+        config = yaml.safe_load(file)
+
+    # Inputs
+    history_file_path = config["input"]["history_file_path"]
+    golden_df_file_path = config["input"]["golden_df_file_path"]
+    row_limit = config["input"]["history_row_limit"]
+    input_dir = config["input"]["input_dir"]
+
+    # Output dirs
+    save_result_dir = config["output"]["save_result_dir"]
+    save_eval_dir = config["output"]["save_eval_dir"]
+
+    # Model Settings
+    pooling = config["model"]["pooling"]
+    quantized_model = config["model"]["quantized_model"]
+    preprocess = config["model"]["preprocess_input"]
+    embeddings_exist = config["model"]["embeddings_already_exist"]
+    
+    # Retrieval
+    distance_measure = config["retrieval"]["distance_measure"]
+    k = config["retrieval"]["k"]
+    features = config["retrieval"]["features"]
+    include_non_ml_baseline = config['retrieval']['include_non_ml_baseline']
+    binary_quantization = config['retrieval']['binary_quantization']
+
+    # build run metadata in dict format
+    model_run_details = build_model_run_details_dict(
+         history_file_path,
+         model_name,
+         features,
+         quantized_model,
+         distance_measure,
+         pooling,
+         preprocess,
+         row_limit,
+         k,
+         binary_quantization)
+
+    # features
+    print("features")
+    embeddings_path, browsing_history_file_path = feature_pipeline(
+        history_file_path=history_file_path,
+        model_run_details=model_run_details,
+        embeddings_exist=embeddings_exist
+    )
+
+    # vector db
+    print("vector db")
+    db, queries, processed_golden_df_path  = vector_db_pipeline(
+        browsing_history_path=browsing_history_file_path,
+        golden_df_file_path=golden_df_file_path,
+        model_run_details=model_run_details
+    )
+    
+    # retrieval
+    print("retrieval")
+    retrieval_save_path = retrieval_pipeline(
+        model_run_details=model_run_details,
+        queries=queries,
+        db=db,
+        save_result_dir=save_result_dir,
+        input_dir=input_dir
+    )
+
+    # non ML baseline (if specified)
+    print("non ML")
+    if include_non_ml_baseline:
+        saved_files = non_ml_baseline_pipeline(
+            history_file_path=history_file_path,
+            save_dir=save_result_dir,
+            query_file_path=golden_df_file_path,
+            model_run_details=model_run_details
+        )
+
+        for non_ml_file in saved_files:
+            evaluation_pipeline(
+                run_llm_judge=False,
+                file_path=non_ml_file,
+                log_to_wandb=False,
+                save_eval_dir=save_eval_dir,
+                result_dir=save_result_dir
+            )
+
+
+    # evaluation
+    print("evaluation")
+    write_file_path = evaluation_pipeline(
+        run_llm_judge=False,
+        file_path=retrieval_save_path,
+        log_to_wandb=False,
+        save_eval_dir=save_eval_dir,
+        result_dir=save_result_dir
+    )
+
+    del model_run_details, embeddings_path, browsing_history_file_path
+    del db, queries, processed_golden_df_path, retrieval_save_path
+    gc.collect()  # Force garbage collection
+
+    return write_file_path
+
+
+def run_model(config, model_name):
+    """Wrapper function to run full_pipeline in a separate process"""
+    try:
+        full_pipeline(config, model_name)
+    except Exception as e:
+        print(f"Error running model {model_name}: {e}")
+
+def main(config_path):
+    """Loops through models and runs full_pipeline for each in a separate process"""
+
+    # Load the config file
+    with open(config_path, "r") as file:
+        config = yaml.safe_load(file)
+
+    processes = []
+
+    for model_name in config["model_names"]:
+        print(f"Starting model run: {model_name}")
+
+        # Create a new process for each model
+        p = multiprocessing.Process(target=run_model, args=(config_path, model_name))
+        p.start()
+        processes.append(p)
+
+        # Wait for process to finish before starting the next one (sequential execution)
+        p.join()
+
+    print("All models completed.")
+
+
+if __name__ == "__main__":
+    main("evaluation_pipeline/run_config.yml")

--- a/evaluation_pipeline/run_model_comparison.py
+++ b/evaluation_pipeline/run_model_comparison.py
@@ -1,0 +1,460 @@
+import pickle
+import pandas as pd
+import os
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+import argparse
+import ast
+import numpy as np
+import scipy.stats as stats
+#import scikit_posthocs as sp
+import plotly.express as px
+import plotly.graph_objects as go
+
+def convert_to_mean(value):
+    if isinstance(value, str):
+        value = value.replace('np.int64(', '').replace(')', '')
+        value = value.replace('np.float64(', '').replace(')', '')
+        return np.mean(ast.literal_eval(value))
+    return value
+
+
+def extract_variants(row):
+     model_runs = ast.literal_eval(row['model_run_details'])  # Convert string to dictionary
+     return pd.Series({
+         'quantized': model_runs.get('quantized', None),
+         'distance': model_runs.get('distance_measure', None),
+         'pooling': model_runs.get('pooling', None),
+         'feature_string': model_runs.get('feature_string', None),
+         'preprocess': model_runs.get('preprocess', None),
+         'k': model_runs.get('k', None),
+     })
+
+def load_results(label, eval_results_dir, metrics, k):
+
+    #  List to store DataFrames
+    dataframes = []
+
+    # Iterate over files in the directory
+    for file in os.listdir(eval_results_dir):
+
+
+        if label == "llm":
+
+             if file.endswith(".csv") and 'detailed' and 'llm' in file and f'top{k}' in file:  # Check if the file is a CSV
+                try:
+                    file_path = os.path.join(eval_results_dir, file)
+                    df = pd.read_csv(file_path)
+                    df['file_path'] = file_path
+                    dataframes.append(df)
+                except:
+                    pass
+        elif label == "normalized_eval":
+
+            if file.endswith(".csv") and 'detailed' in file and 'norm' in file and 'traditional' in file and  f'top{k}' in file:  # Check if the file is a CSV
+                try:
+                     file_path = os.path.join(eval_results_dir, file)
+                     df = pd.read_csv(file_path)
+                     df['file_path'] = file_path
+                     dataframes.append(df)
+                except:
+                    pass
+        else:
+
+             if file.endswith(".csv") and 'detailed' in file and 'traditional' in file and f'top{k}' in file and "norm" not in file:  # Check if the file is a CSV
+                try:
+                     file_path = os.path.join(eval_results_dir, file)
+                     
+                     df = pd.read_csv(file_path)
+                     df['file_path'] = file_path
+                     dataframes.append(df)
+                except:
+                    pass
+
+
+    # combined all dfs into one
+    all_data = pd.concat(dataframes, ignore_index=True)
+    model_names = list(all_data['model_name'].unique())
+
+    file_paths = list(all_data['file_path'].unique())
+
+    embedding_sizes = [
+        all_data[all_data['model_name'] == model]['embedding_dim'].iloc[0] if not all_data[all_data['model_name'] == model].empty else 0
+        for model in model_names
+    ]
+
+    variants = [all_data[all_data['file_path'] == file]['model_run_details'].iloc[0] for file in file_paths]
+
+    variant_dict = dict(zip(file_paths, variants))
+    model_size_dict = dict(zip(model_names, embedding_sizes))
+
+    # Group by `model_name`
+    base_metrics = ['model_name', "file_path"]
+    base_metrics.extend(metrics)
+    grouped = all_data[base_metrics].groupby(["file_path",'model_name'])
+
+    # Create the aggregation dictionary based on metric list entered
+    agg_dict = {f"{metric}": "mean" for metric in metrics}
+
+    # Aggregate Metrics
+    agg_metrics = grouped.agg(agg_dict).reset_index()
+    agg_metrics['model_name_normalized'] = agg_metrics['model_name'].replace("/","_").replace("-","_").replace(".","_")
+    agg_metrics['embedding_size'] = agg_metrics['model_name'].map(model_size_dict).fillna(0)
+    agg_metrics['model_run_details'] = agg_metrics['file_path'].map(variant_dict).fillna(0)
+
+
+    # Apply the function to all rows
+    agg_metrics = agg_metrics.join(agg_metrics.apply(extract_variants, axis=1))
+
+    directories = [f"{eval_results_dir}/result_analysis",f"{eval_results_dir}/figs"]
+
+    for directory in directories:
+        if not os.path.exists(directory):
+                os.makedirs(directory)
+                
+
+    # save as csv
+    agg_metrics.to_csv(f'{eval_results_dir}/result_analysis/metric_results_{label}_{k}.csv')
+
+    return agg_metrics, all_data
+
+
+
+def precision_recall_tradeoff(label,k, agg_metrics, eval_results_dir):
+
+    agg_metrics[f"recall@{k}_jitter"] = agg_metrics[f"recall@{k}"] + np.random.uniform(-0.003, 0.003, agg_metrics.shape[0])
+
+    agg_metrics[f"precision@{k}_jitter"] = agg_metrics[f"precision@{k}"] + np.random.uniform(-0.003, 0.003, agg_metrics.shape[0])
+
+    agg_metrics["ml_or_baseline"] = agg_metrics.apply(
+        lambda row: "ml" if (row["embedding_size"] > 0 or "KG" in row["model_name"]) else "baseline",
+        axis=1
+    )
+
+
+    fig = px.scatter(
+        agg_metrics,
+        x=f"recall@{k}_jitter",
+        y=f"precision@{k}_jitter",
+        color="model_name",  # Assign color based on Model
+        symbol="ml_or_baseline",
+        hover_data={
+            "model_name": True,
+            "distance": True,
+            "pooling": True,
+            "feature_string": True,
+            "preprocess": True,
+            "k": True,
+            "quantized":True,
+            f"recall@{k}": True,
+            f"precision@{k}": True,
+            f"precision@{k}_jitter": False,
+            f"recall@{k}_jitter": False,
+            "embedding_size": True,
+
+
+            },  # Tooltip details
+        title=f"Precision vs. Recall (Interactive Model Variants) at {k} {label}"
+
+    )
+
+    # Improve layout
+    fig.update_layout(
+        xaxis_title="Recall",
+        yaxis_title="Precision",
+        hovermode="closest",
+
+    )
+    fig.update_traces(marker=dict(size=11, opacity=.7))  # Adjust the size as needed
+
+    fig.write_html(f"{eval_results_dir}/figs/{label}_precision_recall_{k}_interactive.html")
+    fig.show()
+
+
+
+
+def plot_text_length_vs_metric(all_data, metric, label, k, eval_results_dir,  length_type="words"):
+    """
+    Plots an interactive scatter plot of text length (words or characters) vs. a metric.
+    
+    Args:
+        texts (list of str): List of text strings.
+        metric_values (list of float): Corresponding metric values.
+        metric_name (str): Name of the metric for labeling.
+        length_type (str): "words" for word count, "characters" for character count.
+    """
+    texts = all_data['query'].values.tolist()
+
+    if length_type == "words":
+        lengths = [len(text.split()) for text in texts]
+        x_label = "Word Count"
+    elif length_type == "characters":
+        lengths = [len(text) for text in texts]
+        x_label = "Character Count"
+    else:
+        raise ValueError("length_type must be 'words' or 'characters'")
+
+
+    all_data['length'] = lengths
+    all_data['length_type'] = x_label
+
+
+    fig = px.scatter(
+        all_data,
+        x="length",
+        y=metric,
+        color="model_name",
+        hover_data={"query": True, "length": True, "length_type":True, metric: True, "model_name": True},
+        title=f"{x_label} vs {metric}"
+    )
+
+    fig.update_layout(
+        xaxis_title=x_label,
+        yaxis_title=metric,
+        hovermode="closest"
+    )
+    fig.write_html(f"{eval_results_dir}/figs/{length_type}_{metric}_{label}_{k}_interactive.html")
+    fig.show()
+
+
+
+def plot_bar(label, metric, k, agg_metrics, eval_results_dir):
+    agg_metrics = agg_metrics.sort_values(by=metric, ascending=False)
+
+    agg_metrics["x_numeric"] = agg_metrics["model_name"].astype("category").cat.codes
+    agg_metrics["ml_or_baseline"] = agg_metrics["embedding_size"].apply(lambda x: "ml" if x > 0 else "baseline")
+
+    # Create bar chart for ML models
+    fig = px.bar(
+        agg_metrics,
+        x="x_numeric",
+        y=metric,
+        color="model_name",  # Groups bars by category
+        text="model_name",  # Display model names inside bars
+        title=f"{metric}: {label} Evaluation",
+    )
+
+
+    # Apply Tufte-style layout
+    fig.update_layout(
+        plot_bgcolor="white",  # White background for clarity
+        xaxis=dict(
+            showgrid=False,  # Remove gridlines
+            zeroline=False,  # Remove zero line
+            showline=True,  # Keep axis line
+            linecolor="black",  # Make axis line visible
+            mirror=True,  # Mirror axes for a boxed look
+            tickmode="array",
+            tickvals=agg_metrics["x_numeric"],
+            ticktext=agg_metrics["model_name"],
+            title="Model",
+        ),
+        yaxis=dict(
+            showgrid=True,  # Light gridlines to aid readability
+            gridcolor="lightgray",  # Subtle gridlines
+            zeroline=False,  # Remove zero line
+            showline=True,  # Keep axis line
+            linecolor="black",  # Make axis line visible
+            mirror=True,  # Mirror axes
+            tickmode="auto",
+            ticks="outside",
+            tickcolor="black",
+        ),
+        yaxis_title=metric,
+        hovermode="x unified",  # Show all values at the same x position
+        legend=dict(
+            bordercolor="black",
+            borderwidth=0.5,
+            font=dict(size=12),
+            x=1.02,  # Moves legend outside plot
+            y=1,
+            xanchor="left",
+            yanchor="top",
+        ),
+        font=dict(
+            family="Arial",
+            size=14,
+            color="black",
+        ),
+
+        margin=dict(l=40, r=120, t=40, b=40),  # Extra right margin for legend,
+        showlegend=False  # Hide legend for minimalism
+    )
+
+
+    # Show figure
+    fig.show()
+    fig.write_html(f"{eval_results_dir}/figs/{label}_{metric}_interactive_bar.html")
+
+def plot_interactive_metrics(label, metric, k, agg_metrics, eval_results_dir):
+    """ Generates an interactive scatter plot with hover details """
+
+     # Ensure the model_name is treated as a categorical variable and preserve order
+    agg_metrics["model_name"] = agg_metrics["model_name"].astype("category")
+    agg_metrics["x_numeric"] = agg_metrics["model_name"].cat.codes  # Assign categorical indices
+    model_order = agg_metrics["model_name"].cat.categories  # Get ordered labels
+
+    np.random.seed(42)
+    agg_metrics["x_jittered"] = agg_metrics["x_numeric"] + np.random.uniform(-0.1, 0.1, size=len(agg_metrics))  # Small jitter
+    agg_metrics["ml_or_baseline"] = agg_metrics["embedding_size"].apply(lambda x: "ml" if x > 0 else "baseline")
+
+    fig = px.scatter(
+        agg_metrics,
+        x="x_jittered",
+        y=metric,
+        color="model_name",
+        symbol="ml_or_baseline",
+        hover_data={
+            metric: True,
+            "model_name": True,
+            "distance": True,
+            "pooling": True,
+            "feature_string": True,
+            "preprocess": True,
+            "k": True,
+            "quantized":True,
+            "x_jittered":False,
+            "embedding_size": True,
+        },
+
+        title=f"Model Variants Performance at {k} - {metric} - {label}"
+    )
+
+
+    fig.update_layout(
+        plot_bgcolor="white",  # White background for clarity
+        xaxis=dict(
+            showgrid=False,  # Remove gridlines
+            zeroline=False,  # Remove zero line
+            showline=True,  # Keep axis line
+            linecolor="black",  # Make axis line visible
+            mirror=True,  # Mirror axes for a boxed look
+         #   tickmode="auto",
+            ticks="outside",
+            tickcolor="black",
+            tickmode="array",
+            tickvals=agg_metrics["x_numeric"].unique(),
+            ticktext=model_order,
+            title="Model",
+        ),
+        yaxis=dict(
+            showgrid=False,  # Remove gridlines
+            zeroline=False,  # Remove zero line
+            showline=True,  # Keep axis line
+            linecolor="black",  # Make axis line visible
+            mirror=True,  # Mirror axes
+            tickmode="auto",
+            ticks="outside",
+            tickcolor="black",
+        ),
+        yaxis_title=metric,
+        hovermode="closest",
+        legend=dict(
+            bordercolor="black",
+            borderwidth=0.5,
+            font=dict(size=12),
+            x=1.7,
+            y=1,
+            xanchor="right",
+            yanchor="top",
+        ),
+        font=dict(
+            family="Arial",  # Simple, readable font
+            size=14,
+            color="black",
+        ),
+        margin=dict(l=40, r=150, t=40, b=80),
+        showlegend=False  # Hide legend for minimalism
+    )
+
+
+    fig.update_traces(marker=dict(size=11, opacity=0.7))  # Adjust the size as needed
+
+
+    fig.write_html(f"{eval_results_dir}/figs/{label}_{metric}_interactive.html")
+    fig.show()
+
+
+def plot_metrics(label, metric, k, agg_metrics, color_map, eval_results_dir):
+
+    if label == "jaccard_index" or label == "overlap_coefficient":
+        pass
+    else: pass
+    #    stat_sig_test(df, metric)
+
+
+    # Sort the DataFrame by the metric in descending order
+    sorted_data = agg_metrics.sort_values(by=metric, ascending=True)
+
+    # Map colors to the sorted data
+    sorted_colors = sorted_data["embedding_size"].map(color_map)
+
+
+    # Bar plot
+    plt.figure(figsize=(8, 6))
+    plt.barh(sorted_data["model_name"], sorted_data[metric], color=sorted_colors)
+
+    # Create a custom legend
+    handles = [plt.Rectangle((0, 0), 1, 1, color=color_map[size]) for size in color_map]
+    labels = [f"{size}" for size in color_map]
+    plt.legend(handles, labels, title="Embedding Dim", loc="upper center", bbox_to_anchor=(0.5, -0.2))
+    # Increase the marker size
+
+    # Customize plot
+    plt.title(f"{metric} by Model Name at {k}- {label}")
+    plt.xlabel(metric)
+    plt.ylabel("Model Name")
+    plt.tight_layout()
+    plt.savefig(f"{eval_results_dir}/figs/{label}_{metric}_by_model_name.png")
+
+
+
+def main(llm, k,  eval_results_dir):
+
+    labels = ['traditional_eval','normalized_eval']
+
+    if llm:
+        labels.append('llm')
+
+    color_map = {
+        384.: "blue",  # Color for embedding size 348
+        768.: "green",  # Color for embedding size 768
+        0.: "pink",
+    }
+
+    # metric sets
+    traditional_metrics = [f'precision@{k}', f'recall@{k}']
+    llm_metrics = [f'on_topic_rate@{k}']
+
+
+    for label in labels:
+        if label == 'llm':
+             # llm judge metrics
+             agg_metrics, all_data =  load_results(label,  eval_results_dir=eval_results_dir, metrics=llm_metrics, k=k)
+             for metric in llm_metrics:
+                plot_bar(label, metric, k, agg_metrics, eval_results_dir)
+        else:
+             # traditional metrics
+             agg_metrics, all_data =  load_results(label, eval_results_dir=eval_results_dir, metrics=traditional_metrics, k=k)
+             for metric in traditional_metrics:
+                 plot_bar(label, metric, k, agg_metrics, eval_results_dir)
+
+
+
+if __name__ == "__main__":
+      # Create the argument parser
+      parser = argparse.ArgumentParser(description="Compare model results")
+       # Add arguments
+      parser.add_argument("--eval_results_dir", default="evaluation_results/", type=str, help="Eval results directory")
+      parser.add_argument("--k", type=int, default=2, help="Top-K results used in retrieval being evaluated.")
+      parser.add_argument("--llm", type=bool, default=False, help="whether LLM judge reuslts are included")
+
+      args = parser.parse_args()
+      # Call the main function with parsed arguments
+      main(
+          llm=args.llm,
+          k=args.k,
+          eval_results_dir = args.eval_results_dir
+      )
+


### PR DESCRIPTION
This MR refactors the evaluation pipeline and integrates feedback from previous review.  See `readme.md` for run instructions. 

The motivation for the change is to break apart the pipeline into more modular steps, and also to run the models via. config file in lieu of a shell script to be more user friendly. 

Also implements a number of cleanup steps related to memory cleanup, in addition to running as a multiprocess to avoid things staying in memory between runs 

# Note: 
- the binary quantization is not yet functional  
